### PR TITLE
Add ALL option to Missions table Show Items with active indicator

### DIFF
--- a/smdb/smdb/static/css/map_compilation_filter.css
+++ b/smdb/smdb/static/css/map_compilation_filter.css
@@ -1,36 +1,129 @@
-/* body {
-    margin-left: 20px;
-    margin-right: 20px;
-} */
-html,
-#map_compilation_filter {
+/* map_compilation_filter.css
+ *
+ * Styles for the Compilations filter page map, labels, hover interactions,
+ * and fixed scrollable table layout — matching the Missions page behaviour.
+ */
+
+/* ── Map container ──────────────────────────────────────────────────────── */
+html {
   width: 100%;
-  top: 200px;
 }
+
+#map_compilation_filter {
+  width: 100vw;
+  max-width: 100vw;
+  box-sizing: border-box;
+  top: 150px;
+}
+
+/* No body scrollbar so the map uses full viewport width. */
+body.compilations-page {
+  overflow: hidden;
+}
+
+/* Pin footer to viewport bottom so table wrapper can sit above it. */
+body.compilations-page #footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  background-color: #fff;
+}
+
+/* Reset Leaflet's default margin on control wrappers. */
+.leaflet-control {
+  margin: 0;
+}
+
+/* ── Compilation table scroll wrapper ───────────────────────────────────── */
+/* Position and height are set dynamically by initTableLayout() in          */
+/* map_compilation_filter.js (position:fixed, top=map-bottom, bottom=footer)*/
+#compilation-table-wrapper {
+  overflow-y: auto;
+  overflow-x: auto;
+  min-height: 100px;
+}
+
+#compilation-table-wrapper #tableContainers4 {
+  position: relative;
+  top: 0;
+  width: 100%;
+}
+
+/* ── Table chrome ───────────────────────────────────────────────────────── */
 th,
 td {
   padding: 0 15px;
 }
-.table {
-  margin: 0 10px 0 10px;
+
+.tab div {
+  margin-left: 3rem;
+  margin-right: 3rem;
 }
+
+/* ── Mission name label markers ─────────────────────────────────────────── */
 .label-mission-name {
   font-size: 1.3em;
   text-align: left;
   white-space: nowrap;
-  padding-left:20px;
+  padding-left: 20px;
 }
-.label-mission-name a:link {
-  color: #000000;
-}
+.label-mission-name a:link,
 .label-mission-name a:visited {
-  color: #000000;
+  color: black;
 }
+
+.label-mission-name a:hover {
+  color: yellow;
+}
+
+/* Bidirectional hover: when track/row hovered, label gets .smdb-hover. */
+.label-mission-name.smdb-hover {
+  z-index: 1000;
+}
+.label-mission-name.smdb-hover a {
+  display: inline-block;
+  color: #0066aa;
+  font-weight: 700;
+  padding: 2px 6px 2px 8px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/* Override project.css .leaflet-interactive:hover for compilation labels. */
+#map_compilation_filter .label-mission-name.leaflet-interactive:hover,
+#map_compilation_filter .label-mission-name.leaflet-interactive:focus,
+#map_compilation_filter .leaflet-marker-icon.label-mission-name:hover,
+#map_compilation_filter .leaflet-marker-icon.label-mission-name:focus {
+  border: none;
+  box-shadow: none;
+}
+
+/* ── Utility ────────────────────────────────────────────────────────────── */
 .align-items-center {
-  -ms-flex-align: center!important;
-  align-items: center!important;
+  -ms-flex-align: center !important;
+  align-items: center !important;
   display: flex;
   justify-content: center;
   word-spacing: 2px;
   padding: 3px;
+}
+
+/* ── Yellow hover on nav-track SVG paths ────────────────────────────────── */
+#map_compilation_filter
+  path.leaflet-interactive.smdb-track-line.smdb-geometry-line:hover {
+  stroke: yellow;
+}
+
+/* Programmatic hover: track and row highlight together. */
+#map_compilation_filter
+  path.leaflet-interactive.smdb-track-line.smdb-geometry-line.smdb-hover {
+  stroke: yellow;
+  stroke-width: 5;
+}
+
+tbody tr.smdb-hover {
+  background-color: rgba(255, 255, 0, 0.25);
 }

--- a/smdb/smdb/static/css/map_expedition_filter.css
+++ b/smdb/smdb/static/css/map_expedition_filter.css
@@ -1,37 +1,129 @@
-/* body {
-    margin-left: 20px;
-    margin-right: 20px;
-} */
-html,
-div#map_expedition_filter {
+/* map_expedition_filter.css
+ *
+ * Styles for the Expeditions filter page map, labels, hover interactions,
+ * and fixed scrollable table layout — matching the Missions page behaviour.
+ */
+
+/* ── Map container ──────────────────────────────────────────────────────── */
+html {
   width: 100%;
-  top: 200px;
 }
+
+#map_expedition_filter {
+  width: 100vw;
+  max-width: 100vw;
+  box-sizing: border-box;
+  top: 150px;
+}
+
+/* No body scrollbar so the map uses full viewport width. */
+body.expeditions-page {
+  overflow: hidden;
+}
+
+/* Pin footer to viewport bottom so table wrapper can sit above it. */
+body.expeditions-page #footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  background-color: #fff;
+}
+
+/* Reset Leaflet's default margin on control wrappers. */
+.leaflet-control {
+  margin: 0;
+}
+
+/* ── Expedition table scroll wrapper ────────────────────────────────────── */
+/* Position and height are set dynamically by initTableLayout() in          */
+/* map_expedition_filter.js (position:fixed, top=map-bottom, bottom=footer) */
+#expedition-table-wrapper {
+  overflow-y: auto;
+  overflow-x: auto;
+  min-height: 100px;
+}
+
+#expedition-table-wrapper #tableContainers4 {
+  position: relative;
+  top: 0;
+  width: 100%;
+}
+
+/* ── Table chrome ───────────────────────────────────────────────────────── */
 th,
 td {
   padding: 0 15px;
 }
+
 .tab div {
   margin-left: 3rem;
   margin-right: 3rem;
 }
+
+/* ── Mission name label markers ─────────────────────────────────────────── */
 .label-mission-name {
   font-size: 1.3em;
   text-align: left;
   white-space: nowrap;
-  padding-left:20px;
+  padding-left: 20px;
 }
-.label-mission-name a:link {
-  color: #000000;
-}
+.label-mission-name a:link,
 .label-mission-name a:visited {
-  color: #000000;
+  color: black;
 }
+
+.label-mission-name a:hover {
+  color: yellow;
+}
+
+/* Bidirectional hover: when track/row hovered, label gets .smdb-hover. */
+.label-mission-name.smdb-hover {
+  z-index: 1000;
+}
+.label-mission-name.smdb-hover a {
+  display: inline-block;
+  color: #0066aa;
+  font-weight: 700;
+  padding: 2px 6px 2px 8px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/* Override project.css .leaflet-interactive:hover for expedition labels. */
+#map_expedition_filter .label-mission-name.leaflet-interactive:hover,
+#map_expedition_filter .label-mission-name.leaflet-interactive:focus,
+#map_expedition_filter .leaflet-marker-icon.label-mission-name:hover,
+#map_expedition_filter .leaflet-marker-icon.label-mission-name:focus {
+  border: none;
+  box-shadow: none;
+}
+
+/* ── Utility ────────────────────────────────────────────────────────────── */
 .align-items-center {
-  -ms-flex-align: center!important;
-  align-items: center!important;
+  -ms-flex-align: center !important;
+  align-items: center !important;
   display: flex;
   justify-content: center;
   word-spacing: 2px;
   padding: 3px;
+}
+
+/* ── Yellow hover on nav-track SVG paths ────────────────────────────────── */
+#map_expedition_filter
+  path.leaflet-interactive.smdb-track-line.smdb-geometry-line:hover {
+  stroke: yellow;
+}
+
+/* Programmatic hover: track and row highlight together. */
+#map_expedition_filter
+  path.leaflet-interactive.smdb-track-line.smdb-geometry-line.smdb-hover {
+  stroke: yellow;
+  stroke-width: 5;
+}
+
+tbody tr.smdb-hover {
+  background-color: rgba(255, 255, 0, 0.25);
 }

--- a/smdb/smdb/static/css/project.css
+++ b/smdb/smdb/static/css/project.css
@@ -849,3 +849,9 @@ svg.svg-inline--fa,
 #map .leaflet-mouse-marker {
   display: none !important; /* Remove confusing cursor dot */
 }
+
+/* Active "Show Items" per-page link in the pagination bar */
+a.per-page-active {
+  color: #d35400;
+  text-decoration: underline;
+}

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -1,120 +1,315 @@
-const map = L.map("map_compilation_filter");
-const options = { minZoom: 1, maxZoom: 20 };
+/**
+ * map_compilation_filter.js
+ *
+ * Compilations page map: nav-track styling, bidirectional hover (map ↔ table),
+ * mission name labels, and fixed scrollable table layout — matching the
+ * Missions page behaviour.  Filter sidebar and Draw Square are NOT included.
+ */
+
+// ---------------------------------------------------------------------------
+// Map and base tile layer
+// ---------------------------------------------------------------------------
+const map = L.map("map_compilation_filter", { minZoom: 2, maxZoom: 18 });
+map.zoomControl.setPosition("bottomright");
 
 const gmrt = L.tileLayer.wms(
   "https://www.gmrt.org/services/mapserver/wms_merc?",
-  {
-    layers: "GMRT",
-  }
+  { layers: "GMRT" }
 );
 gmrt.addTo(map);
 
-map.fitWorld();
+// ---------------------------------------------------------------------------
+// Load mission GeoJSON passed by the Django view
+// ---------------------------------------------------------------------------
 const missions = JSON.parse(
   document.getElementById("missions-data").textContent
 );
 
-// Check if missions data is empty before creating GeoJSON layer
-var hasMissions = missions && missions.features && missions.features.length > 0;
+const hasMissions =
+  missions && missions.features && missions.features.length > 0;
 
-let feature = L.geoJSON(missions)
+map.setView([0, 0], 2, { animate: false });
+
+// ---------------------------------------------------------------------------
+// Hover state (bidirectional map ↔ table, issue #293)
+// ---------------------------------------------------------------------------
+var currentHighlightedSlug = null;
+var highlightedLabelEls = [];
+var highlightedPathEls  = [];
+var highlightedRowEls   = [];
+var clearHighlightsTimeout = null;
+var CLEAR_DEBOUNCE_MS = 80;
+
+function clearAllMissionHighlights() {
+  if (!currentHighlightedSlug) return;
+  highlightedLabelEls.forEach(function (el) { el.classList.remove("smdb-hover"); });
+  highlightedPathEls.forEach(function (p)  { p.classList.remove("smdb-hover"); });
+  highlightedRowEls.forEach(function (tr)  { tr.classList.remove("smdb-hover"); });
+  highlightedLabelEls = [];
+  highlightedPathEls  = [];
+  highlightedRowEls   = [];
+  currentHighlightedSlug = null;
+}
+
+function highlightMission(slug) {
+  if (!slug) return;
+  if (clearHighlightsTimeout) {
+    clearTimeout(clearHighlightsTimeout);
+    clearHighlightsTimeout = null;
+  }
+  if (slug === currentHighlightedSlug) return;
+
+  clearAllMissionHighlights();
+  currentHighlightedSlug = slug;
+
+  var escapedSlug = slug.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+  highlightedLabelEls = Array.prototype.slice.call(
+    document.querySelectorAll('.label-mission-name[data-mission-slug="' + escapedSlug + '"]')
+  );
+  highlightedLabelEls.forEach(function (l) {
+    l.classList.add("smdb-hover");
+    var pane = l.closest(".leaflet-marker-pane");
+    if (pane) pane.appendChild(l);
+  });
+
+  var mapEl = document.getElementById("map_compilation_filter");
+  highlightedPathEls = [];
+  if (mapEl) {
+    highlightedPathEls = Array.prototype.slice.call(
+      mapEl.querySelectorAll('path[data-mission-slug="' + escapedSlug + '"]')
+    );
+    highlightedPathEls.forEach(function (p) {
+      p.classList.add("smdb-hover");
+      var parent = p.parentNode;
+      if (parent) parent.appendChild(p);
+    });
+  }
+
+  highlightedRowEls = Array.prototype.slice.call(
+    document.querySelectorAll('tr[data-mission-slug="' + escapedSlug + '"]')
+  );
+  highlightedRowEls.forEach(function (tr) { tr.classList.add("smdb-hover"); });
+
+  var mainTableRow = document.querySelector(
+    '#compilation-table-wrapper tr[data-mission-slug="' + escapedSlug + '"]'
+  );
+  if (mainTableRow) mainTableRow.scrollIntoView({ behavior: "smooth", block: "nearest" });
+}
+
+// ---------------------------------------------------------------------------
+// GeoJSON layer — styled nav-tracks with hover wiring
+// ---------------------------------------------------------------------------
+function _escapeHtml(text) {
+  if (!text) return "";
+  return text.toString().replace(/[&<>"']/g, function (c) {
+    return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#039;" }[c];
+  });
+}
+
+let feature = L.geoJSON(missions, {
+  style: function () {
+    return {
+      color: "rgb(139, 64, 0)",
+      weight: 3.5,
+      opacity: 1,
+      lineCap: "round",
+      lineJoin: "round",
+      fill: false,
+    };
+  },
+  onEachFeature: function (feat, layer) {
+    var slug = (feat.properties && feat.properties.slug) ? feat.properties.slug : "";
+    layer.on("add", function () {
+      if (this._path) {
+        this._path.classList.add("smdb-track-line", "smdb-geometry-line");
+        if (slug) this._path.setAttribute("data-mission-slug", slug);
+        this._path.addEventListener("mouseover", function () { highlightMission(slug); });
+        this._path.addEventListener("mouseout", function () {
+          if (clearHighlightsTimeout) clearTimeout(clearHighlightsTimeout);
+          clearHighlightsTimeout = setTimeout(function () {
+            clearHighlightsTimeout = null;
+            clearAllMissionHighlights();
+          }, CLEAR_DEBOUNCE_MS);
+        });
+      }
+    });
+  },
+})
   .bindPopup(function (layer) {
+    var p = layer.feature.properties;
+    var slug    = (p && p.slug) ? p.slug : "";
+    var expName = (p && p.expedition && p.expedition.name) ? p.expedition.name : "";
+    var routeFile = (p && p.route_file) ? p.route_file : "";
     return (
-      "<a target='_blank' href='/missions/" +
-      layer.feature.properties.slug +
-      "'>" +
-      layer.feature.properties.slug +
-      "</a>: " +
-      layer.feature.properties.expedition.name
+      "<a target='_blank' href='/missions/" + _escapeHtml(slug) + "'>" +
+      _escapeHtml(slug) + "</a>: " + _escapeHtml(expName) +
+      "<br>Route: " + _escapeHtml(routeFile)
     );
   })
   .addTo(map);
 
-// Fit map to mission bounds with checks for empty missions (same logic as home page)
-map.whenReady(function() {
+// ---------------------------------------------------------------------------
+// Fit map to mission bounds
+// ---------------------------------------------------------------------------
+var FALLBACK_CENTER = [39.8423, -26.8945];
+var FALLBACK_ZOOM   = 3;
+map.whenReady(function () {
   map.invalidateSize();
-  
-  setTimeout(function() {
+  setTimeout(function () {
     try {
-      // Check if there are any missions before trying to fit bounds
-      if (!hasMissions) {
-        // No missions found - set to default zoom level 3 and center
-        map.setView([39.8423, -26.8945], 3, { animate: false });
-        return;
-      }
-      
-      // Also check the feature layers as a secondary check
+      if (!hasMissions) { map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return; }
       var featureLayers = feature.getLayers();
-      if (!featureLayers || featureLayers.length === 0) {
-        // No missions found - set to default zoom level 3 and center
-        map.setView([39.8423, -26.8945], 3, { animate: false });
-        return;
-      }
-      
-      // Try to get bounds - this may throw an error if layer is empty
+      if (!featureLayers || featureLayers.length === 0) { map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return; }
       var bounds;
-      try {
-        bounds = feature.getBounds();
-      } catch (boundsError) {
-        // getBounds() failed (likely empty layer) - set to default zoom level 3 and center
-        map.setView([39.8423, -26.8945], 3, { animate: false });
-        return;
+      try { bounds = feature.getBounds(); }
+      catch (e) { map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return; }
+      if (!bounds || !bounds.isValid || !bounds.isValid()) { map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return; }
+      var sw = bounds.getSouthWest(), ne = bounds.getNorthEast();
+      var latSpan = ne.lat - sw.lat, lngSpan = ne.lng - sw.lng;
+      if (isNaN(latSpan) || isNaN(lngSpan) || lngSpan >= 360 || latSpan >= 180) {
+        map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return;
       }
-      
-      if (!bounds || !bounds.isValid || !bounds.isValid()) {
-        // Invalid bounds (likely empty layer) - set to default zoom level 3 and center
-        map.setView([39.8423, -26.8945], 3, { animate: false });
-        return;
-      }
-      
-      // Get mission bounds coordinates
-      var sw = bounds.getSouthWest();
-      var ne = bounds.getNorthEast();
-      var missionLatSpan = ne.lat - sw.lat;
-      var missionLngSpan = ne.lng - sw.lng;
-      
-      // Check if bounds span is too large (indicating invalid/empty bounds or global span)
-      // Also check for extremely large spans that would cause excessive zoom-out
-      if (missionLngSpan >= 360 || missionLatSpan >= 180 || isNaN(missionLatSpan) || isNaN(missionLngSpan) || 
-          missionLngSpan > 350 || missionLatSpan > 170) {
-        // Invalid or global-spanning bounds - set to default zoom level 3 and center
-        map.setView([39.8423, -26.8945], 3, { animate: false });
-        return;
-      }
-      
-      // Valid bounds - fit to bounds with padding
-      map.fitBounds(bounds, { padding: [100, 100] });
+      var padding = [100, 100];
+      var zoomWouldBe = map.getBoundsZoom(bounds, false, padding);
+      if (zoomWouldBe < 2 || !isFinite(zoomWouldBe)) { map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return; }
+      map.fitBounds(bounds, { padding: padding, animate: false });
+      if (map.getZoom() < 4) map.setZoom(4, { animate: false });
     } catch (err) {
-      // On any error, set to default zoom level 3 and center
-      map.setView([39.8423, -26.8945], 3, { animate: false });
+      map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false });
     }
   }, 100);
 });
 
-// Only create markers if there are missions
+// ---------------------------------------------------------------------------
+// Mission name labels at northernmost point of each nav-track
+// ---------------------------------------------------------------------------
 if (hasMissions && missions.features) {
+  var labelPixelOffsetEast  = 8;
+  var labelPixelOffsetNorth = 8;
+  var labelEntries = [];
+
+  function flattenCoords(geometry) {
+    var c = geometry.coordinates;
+    if (!c || !c.length) return [];
+    if (typeof c[0][0] === "number") return c;
+    var out = [];
+    for (var k = 0; k < c.length; k++)
+      for (var m = 0; m < c[k].length; m++) out.push(c[k][m]);
+    return out;
+  }
+
+  function updateLabelPositions() {
+    for (var e = 0; e < labelEntries.length; e++) {
+      var entry = labelEntries[e];
+      var pt = map.latLngToContainerPoint(entry.anchor);
+      var newPt = L.point(pt.x + labelPixelOffsetEast, pt.y - labelPixelOffsetNorth);
+      entry.marker.setLatLng(map.containerPointToLatLng(newPt));
+    }
+  }
+
   for (var i = 0; i < missions.features.length; i++) {
-  var mission = missions.features[i];
-  try {
-    // Use starting point of mission as marker
-    var latlng = L.latLng(
-      mission.geometry.coordinates[0][1],
-      mission.geometry.coordinates[0][0]
-    );
-  } catch (err) {
-    continue;
+    var mission = missions.features[i];
+    var coords  = flattenCoords(mission.geometry);
+    var slug    = (mission.properties && mission.properties.slug) ? mission.properties.slug : "";
+    if (coords.length === 0) continue;
+
+    var maxLat = -Infinity, lngAtMaxLat = coords[0][0];
+    for (var j = 0; j < coords.length; j++) {
+      if (coords[j][1] > maxLat) { maxLat = coords[j][1]; lngAtMaxLat = coords[j][0]; }
+    }
+
+    var anchor = L.latLng(maxLat, lngAtMaxLat);
+    var marker = L.marker(anchor, {
+      icon: L.divIcon({
+        className: "label-mission-name",
+        html: "<a target='_blank' href='/missions/" + _escapeHtml(slug) + "'>" + _escapeHtml(slug) + "</a>",
+      }),
+    });
+    labelEntries.push({ marker: marker, anchor: anchor });
+
+    (function (missionSlug) {
+      marker.on("add", function () {
+        var el = this._icon;
+        if (!el || !missionSlug) return;
+        el.setAttribute("data-mission-slug", missionSlug);
+        el.setAttribute("data-track-side", "left");
+        el.addEventListener("mouseover", function () { highlightMission(missionSlug); });
+        el.addEventListener("mouseout", function () {
+          if (clearHighlightsTimeout) clearTimeout(clearHighlightsTimeout);
+          clearHighlightsTimeout = setTimeout(function () {
+            clearHighlightsTimeout = null;
+            clearAllMissionHighlights();
+          }, CLEAR_DEBOUNCE_MS);
+        });
+      });
+    })(slug);
+
+    marker.addTo(map);
   }
-  var marker = L.marker(latlng, {
-    icon: L.divIcon({
-      className: "label-mission-name",
-      html:
-        "<a target='_blank' href='/missions/" +
-        mission.properties.slug +
-        "'>" +
-        mission.properties.slug +
-        "</a>",
-    }),
+  updateLabelPositions();
+  map.on("zoomend moveend", updateLabelPositions);
+}
+
+// ---------------------------------------------------------------------------
+// Fixed scrollable table layout (table sits below map, above footer)
+// ---------------------------------------------------------------------------
+function initTableLayout() {
+  var mapEl        = document.getElementById("map_compilation_filter");
+  var tableWrapper = document.getElementById("compilation-table-wrapper");
+  if (!tableWrapper || !mapEl) return;
+
+  var footerEl = document.getElementById("footer");
+  var footerH  = footerEl ? footerEl.offsetHeight : 0;
+
+  var mapBottom = Math.round(mapEl.getBoundingClientRect().bottom);
+  tableWrapper.style.position        = "fixed";
+  tableWrapper.style.top             = mapBottom + "px";
+  tableWrapper.style.left            = "0";
+  tableWrapper.style.right           = "0";
+  tableWrapper.style.bottom          = footerH + "px";
+  tableWrapper.style.overflowY       = "auto";
+  tableWrapper.style.overflowX       = "auto";
+  tableWrapper.style.backgroundColor = "#fff";
+  tableWrapper.style.zIndex          = "1";
+  tableWrapper.style.marginTop       = "";
+  tableWrapper.style.height          = "";
+}
+
+setTimeout(initTableLayout, 150);
+window.addEventListener("resize", function () {
+  if (map) map.invalidateSize();
+  setTimeout(initTableLayout, 50);
+});
+
+var mapElForObserver = document.getElementById("map_compilation_filter");
+if (mapElForObserver && typeof ResizeObserver !== "undefined") {
+  var layoutTimeout = null;
+  new ResizeObserver(function () {
+    if (layoutTimeout) clearTimeout(layoutTimeout);
+    layoutTimeout = setTimeout(function () { layoutTimeout = null; initTableLayout(); }, 50);
+  }).observe(mapElForObserver);
+}
+
+// ---------------------------------------------------------------------------
+// Table row hover → highlight map track and label
+// ---------------------------------------------------------------------------
+function attachTableRowHover() {
+  document.querySelectorAll("tr[data-mission-slug]").forEach(function (tr) {
+    var slug = tr.getAttribute("data-mission-slug");
+    if (!slug) return;
+    tr.addEventListener("mouseover", function () { highlightMission(slug); });
+    tr.addEventListener("mouseout", function () {
+      if (clearHighlightsTimeout) clearTimeout(clearHighlightsTimeout);
+      clearHighlightsTimeout = setTimeout(function () {
+        clearHighlightsTimeout = null;
+        clearAllMissionHighlights();
+      }, CLEAR_DEBOUNCE_MS);
+    });
   });
-  marker.addTo(map);
-  }
+}
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", attachTableRowHover);
+} else {
+  attachTableRowHover();
 }

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -86,15 +86,26 @@ function highlightMission(slug) {
     });
   }
 
-  highlightedRowEls = Array.prototype.slice.call(
-    document.querySelectorAll('tr[data-mission-slug="' + escapedSlug + '"]')
-  );
-  highlightedRowEls.forEach(function (tr) { tr.classList.add("smdb-hover"); });
-
-  var mainTableRow = document.querySelector(
-    '#compilation-table-wrapper tr[data-mission-slug="' + escapedSlug + '"]'
-  );
-  if (mainTableRow) mainTableRow.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  // Compilation table rows don't carry data-mission-slug — find the row that
+  // contains a Missions-column link pointing to this mission instead.
+  highlightedRowEls = [];
+  var tableWrapper = document.getElementById("compilation-table-wrapper");
+  if (tableWrapper) {
+    var targetHref = "/missions/" + slug;
+    tableWrapper.querySelectorAll("td a").forEach(function (link) {
+      var href = (link.getAttribute("href") || "").replace(/\/$/, "");
+      if (href === targetHref) {
+        var row = link.closest("tr");
+        if (row && highlightedRowEls.indexOf(row) === -1) {
+          row.classList.add("smdb-hover");
+          highlightedRowEls.push(row);
+        }
+      }
+    });
+  }
+  if (highlightedRowEls.length > 0) {
+    highlightedRowEls[0].scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -292,14 +303,21 @@ if (mapElForObserver && typeof ResizeObserver !== "undefined") {
 }
 
 // ---------------------------------------------------------------------------
-// Table row hover → highlight map track and label
+// Table hover → highlight map track and label
+// Compilation rows hold multiple missions; wire hover to each mission link
+// in the Missions column so hovering any link fires highlightMission().
 // ---------------------------------------------------------------------------
 function attachTableRowHover() {
-  document.querySelectorAll("tr[data-mission-slug]").forEach(function (tr) {
-    var slug = tr.getAttribute("data-mission-slug");
+  var tableWrapper = document.getElementById("compilation-table-wrapper");
+  if (!tableWrapper) return;
+  tableWrapper.querySelectorAll('td a[href*="/missions/"]').forEach(function (link) {
+    var href = (link.getAttribute("href") || "").replace(/\/$/, "");
+    var match = href.match(/\/missions\/([^?#]+)$/);
+    if (!match) return;
+    var slug = match[1];
     if (!slug) return;
-    tr.addEventListener("mouseover", function () { highlightMission(slug); });
-    tr.addEventListener("mouseout", function () {
+    link.addEventListener("mouseover", function () { highlightMission(slug); });
+    link.addEventListener("mouseout", function () {
       if (clearHighlightsTimeout) clearTimeout(clearHighlightsTimeout);
       clearHighlightsTimeout = setTimeout(function () {
         clearHighlightsTimeout = null;

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -39,6 +39,9 @@ var highlightedPathEls  = [];
 var highlightedRowEls   = [];
 var clearHighlightsTimeout = null;
 var CLEAR_DEBOUNCE_MS = 80;
+// Pre-built slug → TR[] index so highlightMission() can do an O(1) row lookup
+// instead of scanning all table links on every hover event.
+var slugRowIndex = null;
 
 function clearAllMissionHighlights() {
   if (!currentHighlightedSlug) return;
@@ -86,22 +89,12 @@ function highlightMission(slug) {
     });
   }
 
-  // Compilation table rows don't carry data-mission-slug — find the row that
-  // contains a Missions-column link pointing to this mission instead.
+  // Use the pre-built slug→row index (built once in attachTableRowHover) for an
+  // O(1) lookup — avoids scanning all table links on every hover event.
   highlightedRowEls = [];
-  var tableWrapper = document.getElementById("compilation-table-wrapper");
-  if (tableWrapper) {
-    var targetHref = "/missions/" + slug;
-    tableWrapper.querySelectorAll("td a").forEach(function (link) {
-      var href = (link.getAttribute("href") || "").replace(/\/$/, "");
-      if (href === targetHref) {
-        var row = link.closest("tr");
-        if (row && highlightedRowEls.indexOf(row) === -1) {
-          row.classList.add("smdb-hover");
-          highlightedRowEls.push(row);
-        }
-      }
-    });
+  if (slugRowIndex && slugRowIndex[slug]) {
+    highlightedRowEls = slugRowIndex[slug].slice();
+    highlightedRowEls.forEach(function (tr) { tr.classList.add("smdb-hover"); });
   }
   if (highlightedRowEls.length > 0) {
     highlightedRowEls[0].scrollIntoView({ behavior: "smooth", block: "nearest" });
@@ -308,14 +301,23 @@ if (mapElForObserver && typeof ResizeObserver !== "undefined") {
 // in the Missions column so hovering any link fires highlightMission().
 // ---------------------------------------------------------------------------
 function attachTableRowHover() {
+  // Build the slug→TR[] index and wire hover events in a single DOM pass so
+  // highlightMission() can do O(1) row lookups instead of scanning on each hover.
+  slugRowIndex = {};
   var tableWrapper = document.getElementById("compilation-table-wrapper");
   if (!tableWrapper) return;
   tableWrapper.querySelectorAll('td a[href*="/missions/"]').forEach(function (link) {
     var href = (link.getAttribute("href") || "").replace(/\/$/, "");
     var match = href.match(/\/missions\/([^?#]+)$/);
-    if (!match) return;
+    if (!match || !match[1]) return;
     var slug = match[1];
-    if (!slug) return;
+
+    var row = link.closest("tr");
+    if (row) {
+      if (!slugRowIndex[slug]) slugRowIndex[slug] = [];
+      if (slugRowIndex[slug].indexOf(row) === -1) slugRowIndex[slug].push(row);
+    }
+
     link.addEventListener("mouseover", function () { highlightMission(slug); });
     link.addEventListener("mouseout", function () {
       if (clearHighlightsTimeout) clearTimeout(clearHighlightsTimeout);

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -153,7 +153,7 @@ let feature = L.geoJSON(missions, {
     var expName = (p && p.expedition && p.expedition.name) ? p.expedition.name : "";
     var routeFile = (p && p.route_file) ? p.route_file : "";
     return (
-      "<a target='_blank' href='/missions/" + _escapeHtml(slug) + "'>" +
+      "<a target='_blank' rel='noopener noreferrer' href='/missions/" + _escapeHtml(slug) + "/'>" +
       _escapeHtml(slug) + "</a>: " + _escapeHtml(expName) +
       "<br>Route: " + _escapeHtml(routeFile)
     );
@@ -234,7 +234,7 @@ if (hasMissions && missions.features) {
     var marker = L.marker(anchor, {
       icon: L.divIcon({
         className: "label-mission-name",
-        html: "<a target='_blank' href='/missions/" + _escapeHtml(slug) + "'>" + _escapeHtml(slug) + "</a>",
+        html: "<a target='_blank' rel='noopener noreferrer' href='/missions/" + _escapeHtml(slug) + "/'>" + _escapeHtml(slug) + "</a>",
       }),
     });
     labelEntries.push({ marker: marker, anchor: anchor });

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -1,120 +1,315 @@
-const map = L.map("map_expedition_filter");
-const options = { minZoom: 1, maxZoom: 20 };
+/**
+ * map_expedition_filter.js
+ *
+ * Expeditions page map: nav-track styling, bidirectional hover (map ↔ table),
+ * mission name labels, and fixed scrollable table layout — matching the
+ * Missions page behaviour.  Filter sidebar and Draw Square are NOT included.
+ */
+
+// ---------------------------------------------------------------------------
+// Map and base tile layer
+// ---------------------------------------------------------------------------
+const map = L.map("map_expedition_filter", { minZoom: 2, maxZoom: 18 });
+map.zoomControl.setPosition("bottomright");
 
 const gmrt = L.tileLayer.wms(
   "https://www.gmrt.org/services/mapserver/wms_merc?",
-  {
-    layers: "GMRT",
-  }
+  { layers: "GMRT" }
 );
 gmrt.addTo(map);
 
-map.fitWorld();
+// ---------------------------------------------------------------------------
+// Load mission GeoJSON passed by the Django view
+// ---------------------------------------------------------------------------
 const missions = JSON.parse(
   document.getElementById("missions-data").textContent
 );
 
-// Check if missions data is empty before creating GeoJSON layer
-var hasMissions = missions && missions.features && missions.features.length > 0;
+const hasMissions =
+  missions && missions.features && missions.features.length > 0;
 
-let feature = L.geoJSON(missions)
+map.setView([0, 0], 2, { animate: false });
+
+// ---------------------------------------------------------------------------
+// Hover state (bidirectional map ↔ table, issue #293)
+// ---------------------------------------------------------------------------
+var currentHighlightedSlug = null;
+var highlightedLabelEls = [];
+var highlightedPathEls  = [];
+var highlightedRowEls   = [];
+var clearHighlightsTimeout = null;
+var CLEAR_DEBOUNCE_MS = 80;
+
+function clearAllMissionHighlights() {
+  if (!currentHighlightedSlug) return;
+  highlightedLabelEls.forEach(function (el) { el.classList.remove("smdb-hover"); });
+  highlightedPathEls.forEach(function (p)  { p.classList.remove("smdb-hover"); });
+  highlightedRowEls.forEach(function (tr)  { tr.classList.remove("smdb-hover"); });
+  highlightedLabelEls = [];
+  highlightedPathEls  = [];
+  highlightedRowEls   = [];
+  currentHighlightedSlug = null;
+}
+
+function highlightMission(slug) {
+  if (!slug) return;
+  if (clearHighlightsTimeout) {
+    clearTimeout(clearHighlightsTimeout);
+    clearHighlightsTimeout = null;
+  }
+  if (slug === currentHighlightedSlug) return;
+
+  clearAllMissionHighlights();
+  currentHighlightedSlug = slug;
+
+  var escapedSlug = slug.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+  highlightedLabelEls = Array.prototype.slice.call(
+    document.querySelectorAll('.label-mission-name[data-mission-slug="' + escapedSlug + '"]')
+  );
+  highlightedLabelEls.forEach(function (l) {
+    l.classList.add("smdb-hover");
+    var pane = l.closest(".leaflet-marker-pane");
+    if (pane) pane.appendChild(l);
+  });
+
+  var mapEl = document.getElementById("map_expedition_filter");
+  highlightedPathEls = [];
+  if (mapEl) {
+    highlightedPathEls = Array.prototype.slice.call(
+      mapEl.querySelectorAll('path[data-mission-slug="' + escapedSlug + '"]')
+    );
+    highlightedPathEls.forEach(function (p) {
+      p.classList.add("smdb-hover");
+      var parent = p.parentNode;
+      if (parent) parent.appendChild(p);
+    });
+  }
+
+  highlightedRowEls = Array.prototype.slice.call(
+    document.querySelectorAll('tr[data-mission-slug="' + escapedSlug + '"]')
+  );
+  highlightedRowEls.forEach(function (tr) { tr.classList.add("smdb-hover"); });
+
+  var mainTableRow = document.querySelector(
+    '#expedition-table-wrapper tr[data-mission-slug="' + escapedSlug + '"]'
+  );
+  if (mainTableRow) mainTableRow.scrollIntoView({ behavior: "smooth", block: "nearest" });
+}
+
+// ---------------------------------------------------------------------------
+// GeoJSON layer — styled nav-tracks with hover wiring
+// ---------------------------------------------------------------------------
+function _escapeHtml(text) {
+  if (!text) return "";
+  return text.toString().replace(/[&<>"']/g, function (c) {
+    return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#039;" }[c];
+  });
+}
+
+let feature = L.geoJSON(missions, {
+  style: function () {
+    return {
+      color: "rgb(139, 64, 0)",
+      weight: 3.5,
+      opacity: 1,
+      lineCap: "round",
+      lineJoin: "round",
+      fill: false,
+    };
+  },
+  onEachFeature: function (feat, layer) {
+    var slug = (feat.properties && feat.properties.slug) ? feat.properties.slug : "";
+    layer.on("add", function () {
+      if (this._path) {
+        this._path.classList.add("smdb-track-line", "smdb-geometry-line");
+        if (slug) this._path.setAttribute("data-mission-slug", slug);
+        this._path.addEventListener("mouseover", function () { highlightMission(slug); });
+        this._path.addEventListener("mouseout", function () {
+          if (clearHighlightsTimeout) clearTimeout(clearHighlightsTimeout);
+          clearHighlightsTimeout = setTimeout(function () {
+            clearHighlightsTimeout = null;
+            clearAllMissionHighlights();
+          }, CLEAR_DEBOUNCE_MS);
+        });
+      }
+    });
+  },
+})
   .bindPopup(function (layer) {
+    var p = layer.feature.properties;
+    var slug    = (p && p.slug) ? p.slug : "";
+    var expName = (p && p.expedition && p.expedition.name) ? p.expedition.name : "";
+    var routeFile = (p && p.route_file) ? p.route_file : "";
     return (
-      "<a target='_blank' href='/missions/" +
-      layer.feature.properties.slug +
-      "'>" +
-      layer.feature.properties.slug +
-      "</a>: " +
-      layer.feature.properties.expedition.name
+      "<a target='_blank' href='/missions/" + _escapeHtml(slug) + "'>" +
+      _escapeHtml(slug) + "</a>: " + _escapeHtml(expName) +
+      "<br>Route: " + _escapeHtml(routeFile)
     );
   })
   .addTo(map);
 
-// Fit map to mission bounds with checks for empty missions (same logic as home page)
-map.whenReady(function() {
+// ---------------------------------------------------------------------------
+// Fit map to mission bounds
+// ---------------------------------------------------------------------------
+var FALLBACK_CENTER = [39.8423, -26.8945];
+var FALLBACK_ZOOM   = 3;
+map.whenReady(function () {
   map.invalidateSize();
-  
-  setTimeout(function() {
+  setTimeout(function () {
     try {
-      // Check if there are any missions before trying to fit bounds
-      if (!hasMissions) {
-        // No missions found - set to default zoom level 3 and center
-        map.setView([39.8423, -26.8945], 3, { animate: false });
-        return;
-      }
-      
-      // Also check the feature layers as a secondary check
+      if (!hasMissions) { map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return; }
       var featureLayers = feature.getLayers();
-      if (!featureLayers || featureLayers.length === 0) {
-        // No missions found - set to default zoom level 3 and center
-        map.setView([39.8423, -26.8945], 3, { animate: false });
-        return;
-      }
-      
-      // Try to get bounds - this may throw an error if layer is empty
+      if (!featureLayers || featureLayers.length === 0) { map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return; }
       var bounds;
-      try {
-        bounds = feature.getBounds();
-      } catch (boundsError) {
-        // getBounds() failed (likely empty layer) - set to default zoom level 3 and center
-        map.setView([39.8423, -26.8945], 3, { animate: false });
-        return;
+      try { bounds = feature.getBounds(); }
+      catch (e) { map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return; }
+      if (!bounds || !bounds.isValid || !bounds.isValid()) { map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return; }
+      var sw = bounds.getSouthWest(), ne = bounds.getNorthEast();
+      var latSpan = ne.lat - sw.lat, lngSpan = ne.lng - sw.lng;
+      if (isNaN(latSpan) || isNaN(lngSpan) || lngSpan >= 360 || latSpan >= 180) {
+        map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return;
       }
-      
-      if (!bounds || !bounds.isValid || !bounds.isValid()) {
-        // Invalid bounds (likely empty layer) - set to default zoom level 3 and center
-        map.setView([39.8423, -26.8945], 3, { animate: false });
-        return;
-      }
-      
-      // Get mission bounds coordinates
-      var sw = bounds.getSouthWest();
-      var ne = bounds.getNorthEast();
-      var missionLatSpan = ne.lat - sw.lat;
-      var missionLngSpan = ne.lng - sw.lng;
-      
-      // Check if bounds span is too large (indicating invalid/empty bounds or global span)
-      // Also check for extremely large spans that would cause excessive zoom-out
-      if (missionLngSpan >= 360 || missionLatSpan >= 180 || isNaN(missionLatSpan) || isNaN(missionLngSpan) || 
-          missionLngSpan > 350 || missionLatSpan > 170) {
-        // Invalid or global-spanning bounds - set to default zoom level 3 and center
-        map.setView([39.8423, -26.8945], 3, { animate: false });
-        return;
-      }
-      
-      // Valid bounds - fit to bounds with padding
-      map.fitBounds(bounds, { padding: [100, 100] });
+      var padding = [100, 100];
+      var zoomWouldBe = map.getBoundsZoom(bounds, false, padding);
+      if (zoomWouldBe < 2 || !isFinite(zoomWouldBe)) { map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false }); return; }
+      map.fitBounds(bounds, { padding: padding, animate: false });
+      if (map.getZoom() < 4) map.setZoom(4, { animate: false });
     } catch (err) {
-      // On any error, set to default zoom level 3 and center
-      map.setView([39.8423, -26.8945], 3, { animate: false });
+      map.setView(FALLBACK_CENTER, FALLBACK_ZOOM, { animate: false });
     }
   }, 100);
 });
 
-// Only create markers if there are missions
+// ---------------------------------------------------------------------------
+// Mission name labels at northernmost point of each nav-track
+// ---------------------------------------------------------------------------
 if (hasMissions && missions.features) {
+  var labelPixelOffsetEast  = 8;
+  var labelPixelOffsetNorth = 8;
+  var labelEntries = [];
+
+  function flattenCoords(geometry) {
+    var c = geometry.coordinates;
+    if (!c || !c.length) return [];
+    if (typeof c[0][0] === "number") return c;
+    var out = [];
+    for (var k = 0; k < c.length; k++)
+      for (var m = 0; m < c[k].length; m++) out.push(c[k][m]);
+    return out;
+  }
+
+  function updateLabelPositions() {
+    for (var e = 0; e < labelEntries.length; e++) {
+      var entry = labelEntries[e];
+      var pt = map.latLngToContainerPoint(entry.anchor);
+      var newPt = L.point(pt.x + labelPixelOffsetEast, pt.y - labelPixelOffsetNorth);
+      entry.marker.setLatLng(map.containerPointToLatLng(newPt));
+    }
+  }
+
   for (var i = 0; i < missions.features.length; i++) {
-  var mission = missions.features[i];
-  try {
-    // Use starting point of mission as marker
-    var latlng = L.latLng(
-      mission.geometry.coordinates[0][1],
-      mission.geometry.coordinates[0][0]
-    );
-  } catch (err) {
-    continue;
+    var mission = missions.features[i];
+    var coords  = flattenCoords(mission.geometry);
+    var slug    = (mission.properties && mission.properties.slug) ? mission.properties.slug : "";
+    if (coords.length === 0) continue;
+
+    var maxLat = -Infinity, lngAtMaxLat = coords[0][0];
+    for (var j = 0; j < coords.length; j++) {
+      if (coords[j][1] > maxLat) { maxLat = coords[j][1]; lngAtMaxLat = coords[j][0]; }
+    }
+
+    var anchor = L.latLng(maxLat, lngAtMaxLat);
+    var marker = L.marker(anchor, {
+      icon: L.divIcon({
+        className: "label-mission-name",
+        html: "<a target='_blank' href='/missions/" + _escapeHtml(slug) + "'>" + _escapeHtml(slug) + "</a>",
+      }),
+    });
+    labelEntries.push({ marker: marker, anchor: anchor });
+
+    (function (missionSlug) {
+      marker.on("add", function () {
+        var el = this._icon;
+        if (!el || !missionSlug) return;
+        el.setAttribute("data-mission-slug", missionSlug);
+        el.setAttribute("data-track-side", "left");
+        el.addEventListener("mouseover", function () { highlightMission(missionSlug); });
+        el.addEventListener("mouseout", function () {
+          if (clearHighlightsTimeout) clearTimeout(clearHighlightsTimeout);
+          clearHighlightsTimeout = setTimeout(function () {
+            clearHighlightsTimeout = null;
+            clearAllMissionHighlights();
+          }, CLEAR_DEBOUNCE_MS);
+        });
+      });
+    })(slug);
+
+    marker.addTo(map);
   }
-  var marker = L.marker(latlng, {
-    icon: L.divIcon({
-      className: "label-mission-name",
-      html:
-        "<a target='_blank' href='/missions/" +
-        mission.properties.slug +
-        "'>" +
-        mission.properties.slug +
-        "</a>",
-    }),
+  updateLabelPositions();
+  map.on("zoomend moveend", updateLabelPositions);
+}
+
+// ---------------------------------------------------------------------------
+// Fixed scrollable table layout (table sits below map, above footer)
+// ---------------------------------------------------------------------------
+function initTableLayout() {
+  var mapEl        = document.getElementById("map_expedition_filter");
+  var tableWrapper = document.getElementById("expedition-table-wrapper");
+  if (!tableWrapper || !mapEl) return;
+
+  var footerEl = document.getElementById("footer");
+  var footerH  = footerEl ? footerEl.offsetHeight : 0;
+
+  var mapBottom = Math.round(mapEl.getBoundingClientRect().bottom);
+  tableWrapper.style.position        = "fixed";
+  tableWrapper.style.top             = mapBottom + "px";
+  tableWrapper.style.left            = "0";
+  tableWrapper.style.right           = "0";
+  tableWrapper.style.bottom          = footerH + "px";
+  tableWrapper.style.overflowY       = "auto";
+  tableWrapper.style.overflowX       = "auto";
+  tableWrapper.style.backgroundColor = "#fff";
+  tableWrapper.style.zIndex          = "1";
+  tableWrapper.style.marginTop       = "";
+  tableWrapper.style.height          = "";
+}
+
+setTimeout(initTableLayout, 150);
+window.addEventListener("resize", function () {
+  if (map) map.invalidateSize();
+  setTimeout(initTableLayout, 50);
+});
+
+var mapElForObserver = document.getElementById("map_expedition_filter");
+if (mapElForObserver && typeof ResizeObserver !== "undefined") {
+  var layoutTimeout = null;
+  new ResizeObserver(function () {
+    if (layoutTimeout) clearTimeout(layoutTimeout);
+    layoutTimeout = setTimeout(function () { layoutTimeout = null; initTableLayout(); }, 50);
+  }).observe(mapElForObserver);
+}
+
+// ---------------------------------------------------------------------------
+// Table row hover → highlight map track and label
+// ---------------------------------------------------------------------------
+function attachTableRowHover() {
+  document.querySelectorAll("tr[data-mission-slug]").forEach(function (tr) {
+    var slug = tr.getAttribute("data-mission-slug");
+    if (!slug) return;
+    tr.addEventListener("mouseover", function () { highlightMission(slug); });
+    tr.addEventListener("mouseout", function () {
+      if (clearHighlightsTimeout) clearTimeout(clearHighlightsTimeout);
+      clearHighlightsTimeout = setTimeout(function () {
+        clearHighlightsTimeout = null;
+        clearAllMissionHighlights();
+      }, CLEAR_DEBOUNCE_MS);
+    });
   });
-  marker.addTo(map);
-  }
+}
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", attachTableRowHover);
+} else {
+  attachTableRowHover();
 }

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -39,6 +39,9 @@ var highlightedPathEls  = [];
 var highlightedRowEls   = [];
 var clearHighlightsTimeout = null;
 var CLEAR_DEBOUNCE_MS = 80;
+// Pre-built slug → TR[] index so highlightMission() can do an O(1) row lookup
+// instead of scanning all table links on every hover event.
+var slugRowIndex = null;
 
 function clearAllMissionHighlights() {
   if (!currentHighlightedSlug) return;
@@ -86,22 +89,12 @@ function highlightMission(slug) {
     });
   }
 
-  // Expedition table rows don't carry data-mission-slug — find the row that
-  // contains a Missions-column link pointing to this mission instead.
+  // Use the pre-built slug→row index (built once in attachTableRowHover) for an
+  // O(1) lookup — avoids scanning all table links on every hover event.
   highlightedRowEls = [];
-  var tableWrapper = document.getElementById("expedition-table-wrapper");
-  if (tableWrapper) {
-    var targetHref = "/missions/" + slug;
-    tableWrapper.querySelectorAll("td a").forEach(function (link) {
-      var href = (link.getAttribute("href") || "").replace(/\/$/, "");
-      if (href === targetHref) {
-        var row = link.closest("tr");
-        if (row && highlightedRowEls.indexOf(row) === -1) {
-          row.classList.add("smdb-hover");
-          highlightedRowEls.push(row);
-        }
-      }
-    });
+  if (slugRowIndex && slugRowIndex[slug]) {
+    highlightedRowEls = slugRowIndex[slug].slice();
+    highlightedRowEls.forEach(function (tr) { tr.classList.add("smdb-hover"); });
   }
   if (highlightedRowEls.length > 0) {
     highlightedRowEls[0].scrollIntoView({ behavior: "smooth", block: "nearest" });
@@ -308,14 +301,23 @@ if (mapElForObserver && typeof ResizeObserver !== "undefined") {
 // in the Missions column so hovering any link fires highlightMission().
 // ---------------------------------------------------------------------------
 function attachTableRowHover() {
+  // Build the slug→TR[] index and wire hover events in a single DOM pass so
+  // highlightMission() can do O(1) row lookups instead of scanning on each hover.
+  slugRowIndex = {};
   var tableWrapper = document.getElementById("expedition-table-wrapper");
   if (!tableWrapper) return;
   tableWrapper.querySelectorAll('td a[href*="/missions/"]').forEach(function (link) {
     var href = (link.getAttribute("href") || "").replace(/\/$/, "");
     var match = href.match(/\/missions\/([^?#]+)$/);
-    if (!match) return;
+    if (!match || !match[1]) return;
     var slug = match[1];
-    if (!slug) return;
+
+    var row = link.closest("tr");
+    if (row) {
+      if (!slugRowIndex[slug]) slugRowIndex[slug] = [];
+      if (slugRowIndex[slug].indexOf(row) === -1) slugRowIndex[slug].push(row);
+    }
+
     link.addEventListener("mouseover", function () { highlightMission(slug); });
     link.addEventListener("mouseout", function () {
       if (clearHighlightsTimeout) clearTimeout(clearHighlightsTimeout);

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -153,7 +153,7 @@ let feature = L.geoJSON(missions, {
     var expName = (p && p.expedition && p.expedition.name) ? p.expedition.name : "";
     var routeFile = (p && p.route_file) ? p.route_file : "";
     return (
-      "<a target='_blank' href='/missions/" + _escapeHtml(slug) + "'>" +
+      "<a target='_blank' rel='noopener noreferrer' href='/missions/" + _escapeHtml(slug) + "/'>" +
       _escapeHtml(slug) + "</a>: " + _escapeHtml(expName) +
       "<br>Route: " + _escapeHtml(routeFile)
     );
@@ -234,7 +234,7 @@ if (hasMissions && missions.features) {
     var marker = L.marker(anchor, {
       icon: L.divIcon({
         className: "label-mission-name",
-        html: "<a target='_blank' href='/missions/" + _escapeHtml(slug) + "'>" + _escapeHtml(slug) + "</a>",
+        html: "<a target='_blank' rel='noopener noreferrer' href='/missions/" + _escapeHtml(slug) + "/'>" + _escapeHtml(slug) + "</a>",
       }),
     });
     labelEntries.push({ marker: marker, anchor: anchor });

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -86,15 +86,26 @@ function highlightMission(slug) {
     });
   }
 
-  highlightedRowEls = Array.prototype.slice.call(
-    document.querySelectorAll('tr[data-mission-slug="' + escapedSlug + '"]')
-  );
-  highlightedRowEls.forEach(function (tr) { tr.classList.add("smdb-hover"); });
-
-  var mainTableRow = document.querySelector(
-    '#expedition-table-wrapper tr[data-mission-slug="' + escapedSlug + '"]'
-  );
-  if (mainTableRow) mainTableRow.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  // Expedition table rows don't carry data-mission-slug — find the row that
+  // contains a Missions-column link pointing to this mission instead.
+  highlightedRowEls = [];
+  var tableWrapper = document.getElementById("expedition-table-wrapper");
+  if (tableWrapper) {
+    var targetHref = "/missions/" + slug;
+    tableWrapper.querySelectorAll("td a").forEach(function (link) {
+      var href = (link.getAttribute("href") || "").replace(/\/$/, "");
+      if (href === targetHref) {
+        var row = link.closest("tr");
+        if (row && highlightedRowEls.indexOf(row) === -1) {
+          row.classList.add("smdb-hover");
+          highlightedRowEls.push(row);
+        }
+      }
+    });
+  }
+  if (highlightedRowEls.length > 0) {
+    highlightedRowEls[0].scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -292,14 +303,21 @@ if (mapElForObserver && typeof ResizeObserver !== "undefined") {
 }
 
 // ---------------------------------------------------------------------------
-// Table row hover → highlight map track and label
+// Table hover → highlight map track and label
+// Expedition rows hold multiple missions; wire hover to each mission link
+// in the Missions column so hovering any link fires highlightMission().
 // ---------------------------------------------------------------------------
 function attachTableRowHover() {
-  document.querySelectorAll("tr[data-mission-slug]").forEach(function (tr) {
-    var slug = tr.getAttribute("data-mission-slug");
+  var tableWrapper = document.getElementById("expedition-table-wrapper");
+  if (!tableWrapper) return;
+  tableWrapper.querySelectorAll('td a[href*="/missions/"]').forEach(function (link) {
+    var href = (link.getAttribute("href") || "").replace(/\/$/, "");
+    var match = href.match(/\/missions\/([^?#]+)$/);
+    if (!match) return;
+    var slug = match[1];
     if (!slug) return;
-    tr.addEventListener("mouseover", function () { highlightMission(slug); });
-    tr.addEventListener("mouseout", function () {
+    link.addEventListener("mouseover", function () { highlightMission(slug); });
+    link.addEventListener("mouseout", function () {
       if (clearHighlightsTimeout) clearTimeout(clearHighlightsTimeout);
       clearHighlightsTimeout = setTimeout(function () {
         clearHighlightsTimeout = null;

--- a/smdb/smdb/static/js/map_mission_filter.js
+++ b/smdb/smdb/static/js/map_mission_filter.js
@@ -158,9 +158,9 @@ let feature = L.geoJSON(missions, {
     var expName = (p && p.expedition && p.expedition.name) ? p.expedition.name : "";
     var routeFile = (p && p.route_file) ? p.route_file : "";
     return (
-      "<a target='_blank' href='/missions/" +
+      "<a target='_blank' rel='noopener noreferrer' href='/missions/" +
       _escapeHtml(slug) +
-      "'>" +
+      "/'>" +
       _escapeHtml(slug) +
       "</a>: " +
       _escapeHtml(expName) +
@@ -276,9 +276,9 @@ if (hasMissions && missions.features) {
       icon: L.divIcon({
         className: "label-mission-name",
         html:
-          "<a target='_blank' href='/missions/" +
+          "<a target='_blank' rel='noopener noreferrer' href='/missions/" +
           (mission.properties.slug ? _escapeHtml(mission.properties.slug) : "") +
-          "'>" +
+          "/'>" +
           (mission.properties.slug ? _escapeHtml(mission.properties.slug) : "") +
           "</a>",
       }),

--- a/smdb/smdb/templates/pages/home.html
+++ b/smdb/smdb/templates/pages/home.html
@@ -114,7 +114,17 @@
 {% endblock %}
 
 {% block content %}
-<script>document.body.classList.add('home-page');</script>
+<script>
+  (function () {
+    if (document.body) {
+      document.body.classList.add('home-page');
+    } else {
+      document.addEventListener('DOMContentLoaded', function () {
+        document.body.classList.add('home-page');
+      });
+    }
+  })();
+</script>
 {#  Number of Missions and Load Log Output #}
 
 <div id="filters" class="row">

--- a/smdb/smdb/templates/smdb/compilation_filter.html
+++ b/smdb/smdb/templates/smdb/compilation_filter.html
@@ -6,7 +6,7 @@
 {% block css %}
   {{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static 'css/map_compilation_filter.css' %}">
-  <link rel="stylesheet" type="text/css" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css">
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/leaflet@1.8.0/dist/leaflet.css">
 {% endblock %}
 
 {% block javascript %}
@@ -24,7 +24,8 @@
     <!-- Load Esri Leaflet Vector from CDN -->
     <script src="https://unpkg.com/esri-leaflet-vector@3.1.1/dist/esri-leaflet-vector.js"
     integrity="sha512-7rLAors9em7cR3/583gZSvu1mxwPBUjWjdFJ000pc4Wpu+fq84lXF1l4dbG4ShiPQ4pSBUTb4e9xaO6xtMZIlA=="
-    crossorigin=""></script> 
+    crossorigin=""></script>
+    <script>document.body.classList.add('compilations-page');</script>
 {% endblock %}
 
 {% block content %}
@@ -33,9 +34,12 @@
     {% crispy filter.form filter.form.helper %}
     {% endif %}
     {{ missions|json_script:"missions-data" }}
-    <div id="map_compilation_filter" style="height: 500px"></div>
+    <div id="map_compilation_filter" style="height: 50vh; min-height: 300px;"></div>
     <script src="{% static 'js/map_compilation_filter.js' %}"></script>
-    {% if table %}
-        {% render_table table "smdb_tables2_bootstrap4.html" %}
-    {% endif %}
+
+    <div id="compilation-table-wrapper">
+      {% if table %}
+          {% render_table table "smdb_tables2_bootstrap4.html" %}
+      {% endif %}
+    </div>
 {% endblock %}

--- a/smdb/smdb/templates/smdb/compilation_filter.html
+++ b/smdb/smdb/templates/smdb/compilation_filter.html
@@ -25,7 +25,17 @@
     <script src="https://unpkg.com/esri-leaflet-vector@3.1.1/dist/esri-leaflet-vector.js"
     integrity="sha512-7rLAors9em7cR3/583gZSvu1mxwPBUjWjdFJ000pc4Wpu+fq84lXF1l4dbG4ShiPQ4pSBUTb4e9xaO6xtMZIlA=="
     crossorigin=""></script>
-    <script>document.body.classList.add('compilations-page');</script>
+    <script>
+      (function () {
+        if (document.body) {
+          document.body.classList.add('compilations-page');
+        } else {
+          document.addEventListener('DOMContentLoaded', function () {
+            document.body.classList.add('compilations-page');
+          });
+        }
+      })();
+    </script>
 {% endblock %}
 
 {% block content %}

--- a/smdb/smdb/templates/smdb/expedition_filter.html
+++ b/smdb/smdb/templates/smdb/expedition_filter.html
@@ -25,7 +25,17 @@
     <script src="https://unpkg.com/esri-leaflet-vector@3.1.1/dist/esri-leaflet-vector.js"
     integrity="sha512-7rLAors9em7cR3/583gZSvu1mxwPBUjWjdFJ000pc4Wpu+fq84lXF1l4dbG4ShiPQ4pSBUTb4e9xaO6xtMZIlA=="
     crossorigin=""></script>
-    <script>document.body.classList.add('expeditions-page');</script>
+    <script>
+      (function () {
+        if (document.body) {
+          document.body.classList.add('expeditions-page');
+        } else {
+          document.addEventListener('DOMContentLoaded', function () {
+            document.body.classList.add('expeditions-page');
+          });
+        }
+      })();
+    </script>
 {% endblock %}
 
 {% block content %}

--- a/smdb/smdb/templates/smdb/expedition_filter.html
+++ b/smdb/smdb/templates/smdb/expedition_filter.html
@@ -6,7 +6,7 @@
 {% block css %}
   {{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static 'css/map_expedition_filter.css' %}">
-  <link rel="stylesheet" type="text/css" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css">
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/leaflet@1.8.0/dist/leaflet.css">
 {% endblock %}
 
 {% block javascript %}
@@ -24,7 +24,8 @@
     <!-- Load Esri Leaflet Vector from CDN -->
     <script src="https://unpkg.com/esri-leaflet-vector@3.1.1/dist/esri-leaflet-vector.js"
     integrity="sha512-7rLAors9em7cR3/583gZSvu1mxwPBUjWjdFJ000pc4Wpu+fq84lXF1l4dbG4ShiPQ4pSBUTb4e9xaO6xtMZIlA=="
-    crossorigin=""></script> 
+    crossorigin=""></script>
+    <script>document.body.classList.add('expeditions-page');</script>
 {% endblock %}
 
 {% block content %}
@@ -33,9 +34,12 @@
     {% crispy filter.form filter.form.helper %}
     {% endif %}
     {{ missions|json_script:"missions-data" }}
-    <div id="map_expedition_filter" style="height: 500px;"></div>
+    <div id="map_expedition_filter" style="height: 50vh; min-height: 300px;"></div>
     <script src="{% static 'js/map_expedition_filter.js' %}"></script>
-    {% if table %}
-        {% render_table table "smdb_tables2_bootstrap4.html" %}
-    {% endif %}
+
+    <div id="expedition-table-wrapper">
+      {% if table %}
+          {% render_table table "smdb_tables2_bootstrap4.html" %}
+      {% endif %}
+    </div>
 {% endblock %}

--- a/smdb/smdb/templates/smdb/mission_filter.html
+++ b/smdb/smdb/templates/smdb/mission_filter.html
@@ -15,7 +15,17 @@
 
 {% block javascript %}
     {{ block.super }}
-    <script>document.body.classList.add('missions-page');</script>
+    <script>
+      (function () {
+        if (document.body) {
+          document.body.classList.add('missions-page');
+        } else {
+          document.addEventListener('DOMContentLoaded', function () {
+            document.body.classList.add('missions-page');
+          });
+        }
+      })();
+    </script>
     <!-- Load Leaflet from CDN -->
     <script src="https://unpkg.com/leaflet@1.8.0/dist/leaflet.js"
     integrity="sha384-4Dmmo81xejNChaqLOci80VhUcuEAD5pXpCtqtizmdgWEzdETh3zrJvzOhU4T79cN"

--- a/smdb/smdb/templates/smdb_tables2_bootstrap4.html
+++ b/smdb/smdb/templates/smdb_tables2_bootstrap4.html
@@ -40,14 +40,14 @@
     {% endif %}
         <li class="align-items-center">
             Show [ 
-            <a href="{% querystring "per_page"=1 %}" {% if request.GET.per_page == "1" %}style="color:#d35400;"{% endif %}>1</a>
-            | <a href="{% querystring "per_page"=2 %}" {% if request.GET.per_page == "2" %}style="color:#d35400;"{% endif %}>2</a>
-            | <a href="{% querystring "per_page"=5 %}" {% if request.GET.per_page == "5" %}style="color:#d35400;"{% endif %}>5</a>
-            | <a href="{% querystring "per_page"=10 %}" {% if request.GET.per_page == "10" %}style="color:#d35400;"{% endif %}>10</a>
-            | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}style="color:#d35400;"{% endif %}>20</a>
-            | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}style="color:#d35400;"{% endif %}>50</a>
-            | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}style="color:#d35400;"{% endif %}>500</a>
-            | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and per_page_all_default %}style="color:#d35400;"{% endif %}>&nbsp;ALL&nbsp;</a>
+            <a href="{% querystring "per_page"=1 %}" {% if request.GET.per_page == "1" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>1</a>
+            | <a href="{% querystring "per_page"=2 %}" {% if request.GET.per_page == "2" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>2</a>
+            | <a href="{% querystring "per_page"=5 %}" {% if request.GET.per_page == "5" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>5</a>
+            | <a href="{% querystring "per_page"=10 %}" {% if request.GET.per_page == "10" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>10</a>
+            | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>20</a>
+            | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>50</a>
+            | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>500</a>
+            | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and per_page_all_default %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>&nbsp;ALL&nbsp;</a>
             ] items
         </li>
         </ul>
@@ -143,14 +143,14 @@
         {% endif %}
             <li class="align-items-center">
                 Show [ 
-                <a href="{% querystring "per_page"=1 %}" {% if request.GET.per_page == "1" %}style="color:#d35400;"{% endif %}>1</a>
-                | <a href="{% querystring "per_page"=2 %}" {% if request.GET.per_page == "2" %}style="color:#d35400;"{% endif %}>2</a>
-                | <a href="{% querystring "per_page"=5 %}" {% if request.GET.per_page == "5" %}style="color:#d35400;"{% endif %}>5</a>
-                | <a href="{% querystring "per_page"=10 %}" {% if request.GET.per_page == "10" %}style="color:#d35400;"{% endif %}>10</a>
-                | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}style="color:#d35400;"{% endif %}>20</a>
-                | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}style="color:#d35400;"{% endif %}>50</a>
-                | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}style="color:#d35400;"{% endif %}>500</a>
-                | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and per_page_all_default %}style="color:#d35400;"{% endif %}>&nbsp;ALL&nbsp;</a>
+                <a href="{% querystring "per_page"=1 %}" {% if request.GET.per_page == "1" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>1</a>
+                | <a href="{% querystring "per_page"=2 %}" {% if request.GET.per_page == "2" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>2</a>
+                | <a href="{% querystring "per_page"=5 %}" {% if request.GET.per_page == "5" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>5</a>
+                | <a href="{% querystring "per_page"=10 %}" {% if request.GET.per_page == "10" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>10</a>
+                | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>20</a>
+                | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>50</a>
+                | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>500</a>
+                | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and per_page_all_default %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>&nbsp;ALL&nbsp;</a>
                 ] items
             </li>
             </ul>

--- a/smdb/smdb/templates/smdb_tables2_bootstrap4.html
+++ b/smdb/smdb/templates/smdb_tables2_bootstrap4.html
@@ -47,7 +47,7 @@
             | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}style="color:#d35400;"{% endif %}>20</a>
             | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}style="color:#d35400;"{% endif %}>50</a>
             | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}style="color:#d35400;"{% endif %}>500</a>
-            | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page %}style="color:#d35400;"{% endif %}>&nbsp;ALL&nbsp;</a>
+            | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and per_page_all_default %}style="color:#d35400;"{% endif %}>&nbsp;ALL&nbsp;</a>
             ] items
         </li>
         </ul>
@@ -150,7 +150,7 @@
                 | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}style="color:#d35400;"{% endif %}>20</a>
                 | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}style="color:#d35400;"{% endif %}>50</a>
                 | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}style="color:#d35400;"{% endif %}>500</a>
-                | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page %}style="color:#d35400;"{% endif %}>&nbsp;ALL&nbsp;</a>
+                | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and per_page_all_default %}style="color:#d35400;"{% endif %}>&nbsp;ALL&nbsp;</a>
                 ] items
             </li>
             </ul>

--- a/smdb/smdb/templates/smdb_tables2_bootstrap4.html
+++ b/smdb/smdb/templates/smdb_tables2_bootstrap4.html
@@ -40,13 +40,14 @@
     {% endif %}
         <li class="align-items-center">
             Show [ 
-            <a href="{% querystring "per_page"=1 %}">1</a>
-            | <a href="{% querystring "per_page"=2 %}">2</a>
-            | <a href="{% querystring "per_page"=5 %}">5</a>
-            | <a href="{% querystring "per_page"=10 %}">10</a>
-            | <a href="{% querystring "per_page"=20 %}">20</a>
-            | <a href="{% querystring "per_page"=50 %}">50</a>
-            | <a href="{% querystring "per_page"=500 %}">500</a>
+            <a href="{% querystring "per_page"=1 %}" {% if request.GET.per_page == "1" %}style="color:#d35400;"{% endif %}>1</a>
+            | <a href="{% querystring "per_page"=2 %}" {% if request.GET.per_page == "2" %}style="color:#d35400;"{% endif %}>2</a>
+            | <a href="{% querystring "per_page"=5 %}" {% if request.GET.per_page == "5" %}style="color:#d35400;"{% endif %}>5</a>
+            | <a href="{% querystring "per_page"=10 %}" {% if request.GET.per_page == "10" %}style="color:#d35400;"{% endif %}>10</a>
+            | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}style="color:#d35400;"{% endif %}>20</a>
+            | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}style="color:#d35400;"{% endif %}>50</a>
+            | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}style="color:#d35400;"{% endif %}>500</a>
+            | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page %}style="color:#d35400;"{% endif %}>&nbsp;ALL&nbsp;</a>
             ] items
         </li>
         </ul>
@@ -142,13 +143,14 @@
         {% endif %}
             <li class="align-items-center">
                 Show [ 
-                <a href="{% querystring "per_page"=1 %}">1</a>
-                | <a href="{% querystring "per_page"=2 %}">2</a>
-                | <a href="{% querystring "per_page"=5 %}">5</a>
-                | <a href="{% querystring "per_page"=10 %}">10</a>
-                | <a href="{% querystring "per_page"=20 %}">20</a>
-                | <a href="{% querystring "per_page"=50 %}">50</a>
-                | <a href="{% querystring "per_page"=500 %}">500</a>
+                <a href="{% querystring "per_page"=1 %}" {% if request.GET.per_page == "1" %}style="color:#d35400;"{% endif %}>1</a>
+                | <a href="{% querystring "per_page"=2 %}" {% if request.GET.per_page == "2" %}style="color:#d35400;"{% endif %}>2</a>
+                | <a href="{% querystring "per_page"=5 %}" {% if request.GET.per_page == "5" %}style="color:#d35400;"{% endif %}>5</a>
+                | <a href="{% querystring "per_page"=10 %}" {% if request.GET.per_page == "10" %}style="color:#d35400;"{% endif %}>10</a>
+                | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}style="color:#d35400;"{% endif %}>20</a>
+                | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}style="color:#d35400;"{% endif %}>50</a>
+                | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}style="color:#d35400;"{% endif %}>500</a>
+                | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page %}style="color:#d35400;"{% endif %}>&nbsp;ALL&nbsp;</a>
                 ] items
             </li>
             </ul>

--- a/smdb/smdb/templates/smdb_tables2_bootstrap4.html
+++ b/smdb/smdb/templates/smdb_tables2_bootstrap4.html
@@ -40,14 +40,14 @@
     {% endif %}
         <li class="align-items-center">
             Show [ 
-            <a href="{% querystring "per_page"=1 %}" {% if request.GET.per_page == "1" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>1</a>
-            | <a href="{% querystring "per_page"=2 %}" {% if request.GET.per_page == "2" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>2</a>
-            | <a href="{% querystring "per_page"=5 %}" {% if request.GET.per_page == "5" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>5</a>
-            | <a href="{% querystring "per_page"=10 %}" {% if request.GET.per_page == "10" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>10</a>
-            | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>20</a>
-            | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>50</a>
-            | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>500</a>
-            | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and table.per_page_all_default %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>&nbsp;ALL&nbsp;</a>
+            <a href="{% querystring "per_page"=1 %}" {% if request.GET.per_page == "1" %}aria-current="page" class="per-page-active"{% endif %}>1</a>
+            | <a href="{% querystring "per_page"=2 %}" {% if request.GET.per_page == "2" %}aria-current="page" class="per-page-active"{% endif %}>2</a>
+            | <a href="{% querystring "per_page"=5 %}" {% if request.GET.per_page == "5" %}aria-current="page" class="per-page-active"{% endif %}>5</a>
+            | <a href="{% querystring "per_page"=10 %}" {% if request.GET.per_page == "10" %}aria-current="page" class="per-page-active"{% endif %}>10</a>
+            | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}aria-current="page" class="per-page-active"{% endif %}>20</a>
+            | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}aria-current="page" class="per-page-active"{% endif %}>50</a>
+            | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}aria-current="page" class="per-page-active"{% endif %}>500</a>
+            | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and table.per_page_all_default %}aria-current="page" class="per-page-active"{% endif %}>&nbsp;ALL&nbsp;</a>
             ] items
         </li>
         </ul>
@@ -143,14 +143,14 @@
         {% endif %}
             <li class="align-items-center">
                 Show [ 
-                <a href="{% querystring "per_page"=1 %}" {% if request.GET.per_page == "1" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>1</a>
-                | <a href="{% querystring "per_page"=2 %}" {% if request.GET.per_page == "2" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>2</a>
-                | <a href="{% querystring "per_page"=5 %}" {% if request.GET.per_page == "5" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>5</a>
-                | <a href="{% querystring "per_page"=10 %}" {% if request.GET.per_page == "10" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>10</a>
-                | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>20</a>
-                | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>50</a>
-                | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>500</a>
-                | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and table.per_page_all_default %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>&nbsp;ALL&nbsp;</a>
+                <a href="{% querystring "per_page"=1 %}" {% if request.GET.per_page == "1" %}aria-current="page" class="per-page-active"{% endif %}>1</a>
+                | <a href="{% querystring "per_page"=2 %}" {% if request.GET.per_page == "2" %}aria-current="page" class="per-page-active"{% endif %}>2</a>
+                | <a href="{% querystring "per_page"=5 %}" {% if request.GET.per_page == "5" %}aria-current="page" class="per-page-active"{% endif %}>5</a>
+                | <a href="{% querystring "per_page"=10 %}" {% if request.GET.per_page == "10" %}aria-current="page" class="per-page-active"{% endif %}>10</a>
+                | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}aria-current="page" class="per-page-active"{% endif %}>20</a>
+                | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}aria-current="page" class="per-page-active"{% endif %}>50</a>
+                | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}aria-current="page" class="per-page-active"{% endif %}>500</a>
+                | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and table.per_page_all_default %}aria-current="page" class="per-page-active"{% endif %}>&nbsp;ALL&nbsp;</a>
                 ] items
             </li>
             </ul>

--- a/smdb/smdb/templates/smdb_tables2_bootstrap4.html
+++ b/smdb/smdb/templates/smdb_tables2_bootstrap4.html
@@ -47,7 +47,7 @@
             | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>20</a>
             | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>50</a>
             | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>500</a>
-            | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and per_page_all_default %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>&nbsp;ALL&nbsp;</a>
+            | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and table.per_page_all_default %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>&nbsp;ALL&nbsp;</a>
             ] items
         </li>
         </ul>
@@ -150,7 +150,7 @@
                 | <a href="{% querystring "per_page"=20 %}" {% if request.GET.per_page == "20" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>20</a>
                 | <a href="{% querystring "per_page"=50 %}" {% if request.GET.per_page == "50" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>50</a>
                 | <a href="{% querystring "per_page"=500 %}" {% if request.GET.per_page == "500" %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>500</a>
-                | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and per_page_all_default %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>&nbsp;ALL&nbsp;</a>
+                | <a href="{% querystring "per_page"="ALL" %}" {% if request.GET.per_page == "ALL" or not request.GET.per_page and table.per_page_all_default %}aria-current="page" style="color:#d35400; text-decoration:underline;"{% endif %}>&nbsp;ALL&nbsp;</a>
                 ] items
             </li>
             </ul>

--- a/smdb/smdb/tests/test_views.py
+++ b/smdb/smdb/tests/test_views.py
@@ -417,3 +417,53 @@ def test_survey_tally_load_citations(missions_notes_5):
     assert mission.citations.count() == 2
     with_ref = Citation.objects.get(doi="10.5678/def")
     assert with_ref.full_reference == "A reference"
+
+
+# ---------------------------------------------------------------------------
+# per_page=ALL and default pagination tests (PR: Show ALL option)
+# ---------------------------------------------------------------------------
+
+def test_missions_per_page_all(client, missions_notes_5):
+    """?per_page=ALL on the Missions page returns 200 and renders all rows."""
+    from smdb.models import Mission
+    url = reverse("missions")
+    response = client.get(url, {"per_page": "ALL"})
+    assert response.status_code == 200
+    table = response.context["table"]
+    rows = list(table.paginated_rows)
+    assert len(rows) == Mission.objects.count()
+
+
+def test_missions_default_shows_all(client, missions_notes_5):
+    """Missions page with no per_page renders all rows by default (get_table_pagination returns False)."""
+    from smdb.models import Mission
+    url = reverse("missions")
+    response = client.get(url)
+    assert response.status_code == 200
+    table = response.context["table"]
+    rows = list(table.paginated_rows)
+    assert len(rows) == Mission.objects.count()
+
+
+def test_missions_numeric_per_page(client, missions_notes_5):
+    """Explicit ?per_page=2 paginates to 2 rows on the Missions page."""
+    url = reverse("missions")
+    response = client.get(url, {"per_page": "2"})
+    assert response.status_code == 200
+    table = response.context["table"]
+    rows = list(table.paginated_rows)
+    assert len(rows) == 2
+
+
+def test_expeditions_per_page_all_no_500(client):
+    """?per_page=ALL on the Expeditions page must not raise a 500 (no bare int() crash)."""
+    url = reverse("expeditions")
+    response = client.get(url, {"per_page": "ALL"})
+    assert response.status_code == 200
+
+
+def test_compilations_per_page_all_no_500(client):
+    """?per_page=ALL on the Compilations page must not raise a 500 (no bare int() crash)."""
+    url = reverse("compilations")
+    response = client.get(url, {"per_page": "ALL"})
+    assert response.status_code == 200

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -384,6 +384,7 @@ class MissionTableView(FilterView, SingleTableView):
     queryset = Mission.objects.all().order_by("name")
     filterset_class = MissionFilter
     formhelper_class = MissionFilterSidebarHelper  # sidebar layout for the collapsible panel
+    paginate_by = 99999  # show all missions by default so hover-scroll works for every row
 
     def _get_bbox_geom(self):
         """Delegate to the module-level _parse_bbox_geom helper."""

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -309,7 +309,10 @@ class CompilationTableView(FilterView, SingleTableView):
         sort = self.request.GET.get("sort")
         if sort and sort in VALID_COMPILATION_SORT:
             compilations = compilations.order_by(sort)
-        per_page = int(self.request.GET.get("per_page", 10))
+        try:
+            per_page = int(self.request.GET.get("per_page", 10))
+        except (TypeError, ValueError):
+            per_page = 99999
         page = int(self.request.GET.get("page", 1))
         compilations = compilations[slice((page - 1) * per_page, page * per_page)]
         missions = Mission.objects.all()
@@ -363,7 +366,10 @@ class ExpeditionTableView(FilterView, SingleTableView):
         sort = self.request.GET.get("sort")
         if sort and sort in VALID_EXPEDITION_SORT:
             expeditions = expeditions.order_by(sort)
-        per_page = int(self.request.GET.get("per_page", 10))
+        try:
+            per_page = int(self.request.GET.get("per_page", 10))
+        except (TypeError, ValueError):
+            per_page = 99999
         page = int(self.request.GET.get("page", 1))
         expeditions = expeditions[slice((page - 1) * per_page, page * per_page)]
         missions = Mission.objects.all()

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -50,6 +50,9 @@ VALID_COMPILATION_SORT = frozenset([
     "name", "-name", "creation_date", "-creation_date",
     "thumbnail_filename", "-thumbnail_filename",
 ])
+# Upper bound for explicit numeric per_page values. Prevents accidental or
+# malicious URLs like ?per_page=100000 from forcing very large table renders.
+MAX_PER_PAGE = 1000
 
 
 class ExpeditionSerializer(HyperlinkedModelSerializer):
@@ -315,8 +318,8 @@ class CompilationTableView(FilterView, SingleTableView):
             per_page = 10
         if per_page <= 0:
             per_page = 10
-        elif per_page > 1000:
-            per_page = 1000
+        elif per_page > MAX_PER_PAGE:
+            per_page = MAX_PER_PAGE
         try:
             page = int(self.request.GET.get("page", 1))
         except (TypeError, ValueError):
@@ -380,8 +383,8 @@ class ExpeditionTableView(FilterView, SingleTableView):
             per_page = 10
         if per_page <= 0:
             per_page = 10
-        elif per_page > 1000:
-            per_page = 1000
+        elif per_page > MAX_PER_PAGE:
+            per_page = MAX_PER_PAGE
         try:
             page = int(self.request.GET.get("page", 1))
         except (TypeError, ValueError):
@@ -440,7 +443,7 @@ class MissionTableView(FilterView, SingleTableView):
             n = int(per_page)
         except (TypeError, ValueError):
             return {}
-        if n <= 0:
+        if n <= 0 or n > MAX_PER_PAGE:
             return {}
         return {"per_page": n}
 

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -312,7 +312,11 @@ class CompilationTableView(FilterView, SingleTableView):
         try:
             per_page = int(self.request.GET.get("per_page", 10))
         except (TypeError, ValueError):
-            per_page = 99999
+            per_page = 10
+        if per_page <= 0:
+            per_page = 10
+        elif per_page > 1000:
+            per_page = 1000
         try:
             page = int(self.request.GET.get("page", 1))
         except (TypeError, ValueError):
@@ -373,7 +377,11 @@ class ExpeditionTableView(FilterView, SingleTableView):
         try:
             per_page = int(self.request.GET.get("per_page", 10))
         except (TypeError, ValueError):
-            per_page = 99999
+            per_page = 10
+        if per_page <= 0:
+            per_page = 10
+        elif per_page > 1000:
+            per_page = 1000
         try:
             page = int(self.request.GET.get("page", 1))
         except (TypeError, ValueError):

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -422,17 +422,22 @@ class MissionTableView(FilterView, SingleTableView):
         """
         Control table pagination based on the per_page query parameter.
 
-        Default (no per_page) and per_page=ALL both disable pagination so every
-        mission is rendered in one page and hover-scroll works for all rows.
-        Explicit positive numeric values (e.g. ?per_page=50) paginate normally.
-        Invalid or non-positive values fall back to default pagination instead
-        of disabling it, to prevent arbitrary unbounded renders.
+        Returning False disables django_tables2 pagination entirely so that
+        every mission row is present in the DOM. This is intentional: the
+        hover-scroll feature (hovering a map label or nav-track scrolls the
+        table to that mission) requires every row to be rendered. A bounded
+        cap (e.g. MISSION_MAX_PER_PAGE) would silently break hover-scroll once
+        the mission count exceeded the cap, with no visible indication to the
+        user. Truly unbounded rendering is therefore the deliberate default.
 
-        Returning False tells django_tables2's RequestConfig to skip pagination
-        entirely — no row cap, truly unbounded.
+        Explicit positive numeric values (e.g. ?per_page=50) paginate normally.
+        Invalid or non-positive values fall back to django_tables2 default
+        pagination instead of disabling it, to prevent arbitrary unbounded
+        renders via malformed URLs.
         """
         per_page = self.request.GET.get("per_page", "")
-        # Missing or explicit ALL: disable pagination (show all rows).
+        # Missing or explicit ALL: disable pagination so all rows are in the DOM
+        # and hover-scroll works for every mission (see docstring above).
         if not per_page:
             return False
         if per_page.upper() == "ALL":

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -313,7 +313,11 @@ class CompilationTableView(FilterView, SingleTableView):
             per_page = int(self.request.GET.get("per_page", 10))
         except (TypeError, ValueError):
             per_page = 99999
-        page = int(self.request.GET.get("page", 1))
+        try:
+            page = int(self.request.GET.get("page", 1))
+        except (TypeError, ValueError):
+            page = 1
+        page = max(1, page)
         compilations = compilations[slice((page - 1) * per_page, page * per_page)]
         missions = Mission.objects.all()
         missions = (
@@ -370,7 +374,11 @@ class ExpeditionTableView(FilterView, SingleTableView):
             per_page = int(self.request.GET.get("per_page", 10))
         except (TypeError, ValueError):
             per_page = 99999
-        page = int(self.request.GET.get("page", 1))
+        try:
+            page = int(self.request.GET.get("page", 1))
+        except (TypeError, ValueError):
+            page = 1
+        page = max(1, page)
         expeditions = expeditions[slice((page - 1) * per_page, page * per_page)]
         missions = Mission.objects.all()
         missions = (

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -391,6 +391,14 @@ class MissionTableView(FilterView, SingleTableView):
     filterset_class = MissionFilter
     formhelper_class = MissionFilterSidebarHelper  # sidebar layout for the collapsible panel
 
+    def get_table(self, **kwargs):
+        """Attach per_page_all_default to the table so the shared table template
+        can highlight ALL on initial load without needing the parent view context
+        (render_table only passes {"table": table} to the sub-template)."""
+        table = super().get_table(**kwargs)
+        table.per_page_all_default = True
+        return table
+
     def get_table_pagination(self, table):
         """
         Control table pagination based on the per_page query parameter.
@@ -486,7 +494,6 @@ class MissionTableView(FilterView, SingleTableView):
 
         missions = missions[slice((map_page - 1) * map_per_page, map_page * map_per_page)]
         context["missions"] = _missions_geojson_list(missions)
-        context["per_page_all_default"] = True  # signals template to highlight ALL when no per_page in URL
         return context
 
 

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -466,6 +466,7 @@ class MissionTableView(FilterView, SingleTableView):
 
         missions = missions[slice((map_page - 1) * map_per_page, map_page * map_per_page)]
         context["missions"] = _missions_geojson_list(missions)
+        context["per_page_all_default"] = True  # signals template to highlight ALL when no per_page in URL
         return context
 
 

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -426,7 +426,7 @@ class MissionTableView(FilterView, SingleTableView):
         every mission row is present in the DOM. This is intentional: the
         hover-scroll feature (hovering a map label or nav-track scrolls the
         table to that mission) requires every row to be rendered. A bounded
-        cap (e.g. MISSION_MAX_PER_PAGE) would silently break hover-scroll once
+        cap (e.g. MAX_PER_PAGE) would silently break hover-scroll once
         the mission count exceeded the cap, with no visible indication to the
         user. Truly unbounded rendering is therefore the deliberate default.
 

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -421,20 +421,28 @@ class MissionTableView(FilterView, SingleTableView):
 
         Default (no per_page) and per_page=ALL both disable pagination so every
         mission is rendered in one page and hover-scroll works for all rows.
-        Explicit numeric values (e.g. ?per_page=50) paginate normally.
+        Explicit positive numeric values (e.g. ?per_page=50) paginate normally.
+        Invalid or non-positive values fall back to default pagination instead
+        of disabling it, to prevent arbitrary unbounded renders.
+
         Returning False tells django_tables2's RequestConfig to skip pagination
         entirely — no row cap, truly unbounded.
         """
         per_page = self.request.GET.get("per_page", "")
-        if not per_page or per_page.upper() == "ALL":
-            return False  # no pagination — all rows rendered
+        # Missing or explicit ALL: disable pagination (show all rows).
+        if not per_page:
+            return False
+        if per_page.upper() == "ALL":
+            return False
+        # Numeric value: positive → explicit page size; non-positive or
+        # unrecognised → fall back to django_tables2 default pagination.
         try:
             n = int(per_page)
-            if n > 0:
-                return {"per_page": n}
         except (TypeError, ValueError):
-            pass
-        return False  # unrecognised value — fall back to all rows
+            return {}
+        if n <= 0:
+            return {}
+        return {"per_page": n}
 
     def _get_bbox_geom(self):
         """Delegate to the module-level _parse_bbox_geom helper."""

--- a/smdb/smdb/views.py
+++ b/smdb/smdb/views.py
@@ -390,7 +390,27 @@ class MissionTableView(FilterView, SingleTableView):
     queryset = Mission.objects.all().order_by("name")
     filterset_class = MissionFilter
     formhelper_class = MissionFilterSidebarHelper  # sidebar layout for the collapsible panel
-    paginate_by = 99999  # show all missions by default so hover-scroll works for every row
+
+    def get_table_pagination(self, table):
+        """
+        Control table pagination based on the per_page query parameter.
+
+        Default (no per_page) and per_page=ALL both disable pagination so every
+        mission is rendered in one page and hover-scroll works for all rows.
+        Explicit numeric values (e.g. ?per_page=50) paginate normally.
+        Returning False tells django_tables2's RequestConfig to skip pagination
+        entirely — no row cap, truly unbounded.
+        """
+        per_page = self.request.GET.get("per_page", "")
+        if not per_page or per_page.upper() == "ALL":
+            return False  # no pagination — all rows rendered
+        try:
+            n = int(per_page)
+            if n > 0:
+                return {"per_page": n}
+        except (TypeError, ValueError):
+            pass
+        return False  # unrecognised value — fall back to all rows
 
     def _get_bbox_geom(self):
         """Delegate to the module-level _parse_bbox_geom helper."""


### PR DESCRIPTION
## Summary

- **ALL option in Show Items**: Adds an `ALL` entry (using `?per_page=ALL` in the URL) to the pagination control on the Missions, Expedition, and Compilation pages.
- **ALL as the default on Missions page load**: `MissionTableView.get_table_pagination()` returns `False` when `per_page` is missing or `ALL`, which tells django_tables2 to skip pagination entirely — truly unbounded, no row cap. This ensures the hover-scroll feature works for every row on initial load without the user needing to manually select ALL.
- **Robust `per_page` handling**: Invalid or non-positive values return `{}` (django_tables2 default pagination) rather than disabling pagination, so garbage URLs like `?per_page=foo` cannot force an unbounded render. All three views enforce an upper bound via the shared `MAX_PER_PAGE = 1000` constant.
- **Active selection indicator**: The active Show Items value is highlighted via the `.per-page-active` CSS class (orange `#d35400`, underlined). On Missions page initial load, ALL is highlighted using `table.per_page_all_default` — a flag attached to the table object in `MissionTableView.get_table()` and read by the shared `smdb_tables2_bootstrap4.html` template. The `aria-current="page"` attribute is also set for accessibility.
- **Expedition and Compilation page parity**: Nav-track styling, mission name labels, and bidirectional hover (map ↔ table) now work on Expedition and Compilation pages, matching the Missions page behaviour. A slug→row index is built once at DOMContentLoaded for O(1) hover lookups. Filter sidebar and Draw Square are intentionally excluded from these pages.
- **Security**: All `target="_blank"` popup/label links now include `rel="noopener noreferrer"` and use canonical trailing-slash URLs (`/missions/<slug>/`).
- **Null-body guard**: Inline scripts that add page-specific CSS classes to `document.body` now include a `DOMContentLoaded` fallback, since they run in `{% block javascript %}` inside `<head>` where `document.body` may be `null`.

## How pagination works (Missions)

`MissionTableView.get_table_pagination()` is called by django_tables2's `SingleTableMixin`:

| `per_page` value | Returned value | Effect |
|---|---|---|
| missing / empty | `False` | Pagination disabled — all rows rendered |
| `ALL` | `False` | Pagination disabled — all rows rendered |
| positive int ≤ 1000 | `{"per_page": n}` | Paginated to n rows |
| non-positive or > 1000 | `{}` | django_tables2 default pagination |
| non-numeric (e.g. `foo`) | `{}` | django_tables2 default pagination |

## Files changed

| File | Change |
|---|---|
| `smdb/smdb/views.py` | `MissionTableView`: override `get_table_pagination()` and `get_table()`; add `MAX_PER_PAGE` constant; robust `per_page`/`page` parsing in Expedition and Compilation views |
| `smdb/smdb/templates/smdb_tables2_bootstrap4.html` | ALL link, `.per-page-active` class on active link, `aria-current="page"` |
| `smdb/smdb/static/css/project.css` | `.per-page-active` rule |
| `smdb/smdb/static/js/map_expedition_filter.js` | Rewritten: nav-track styling, labels, bidirectional hover, `slugRowIndex`, security fixes |
| `smdb/smdb/static/js/map_compilation_filter.js` | Same as expedition |
| `smdb/smdb/static/css/map_expedition_filter.css` | Layout and hover styles |
| `smdb/smdb/static/css/map_compilation_filter.css` | Same as expedition |
| `smdb/smdb/templates/smdb/expedition_filter.html` | Table wrapper div, map height, DOMContentLoaded guard |
| `smdb/smdb/templates/smdb/compilation_filter.html` | Same as expedition |
| `smdb/smdb/templates/smdb/mission_filter.html` | DOMContentLoaded guard |
| `smdb/smdb/templates/pages/home.html` | DOMContentLoaded guard |
| `smdb/smdb/tests/test_views.py` | 5 new tests for `per_page=ALL`, default-all, numeric, and no-500 on Expedition/Compilation |

## Test plan

- [x] All 165 tests pass (`pytest -v` in the Django container)
- [ ] Load the Missions page — table shows all missions by default with **ALL** highlighted in orange
- [ ] Hover over a map track or label — table scrolls smoothly to that mission row
- [ ] Click a numbered option (e.g. 10) — table paginates to 10 rows and **10** turns orange
- [ ] Click ALL — URL shows `?per_page=ALL`, all rows return, **ALL** turns orange
- [ ] `?per_page=foo` and `?per_page=0` do not crash — fall back to default pagination
- [ ] `?per_page=ALL` on Expeditions and Compilations pages returns 200 (no 500)
- [ ] On Expedition and Compilation pages: hovering a map track highlights the correct table row and vice versa
- [ ] Popup/label links open in new tab without reverse-tabnabbing and navigate without redirect