### PR TITLE
ux: Filter/Clear sidebar button hover & click (#297) — review

### DIFF
--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -272,7 +272,12 @@ const FilterControl = L.Control.extend({
       sidebarBtnStyle.textContent =
         '#filter-sidebar-body .btn-primary,' +
         '#filter-sidebar-body .btn-secondary {' +
-        '  cursor: pointer !important;' +
+        '  cursor: pointer;' +
+        '}' +
+        '#filter-sidebar-body .btn-primary:disabled,' +
+        '#filter-sidebar-body .btn-secondary:disabled,' +
+        '#filter-sidebar-body .btn[aria-disabled="true"] {' +
+        '  cursor: default;' +
         '}' +
         '#filter-sidebar-body .btn-primary {' +
         '  transition: background-color 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -287,7 +287,7 @@ const FilterControl = L.Control.extend({
         '}' +
         '#filter-sidebar-body .btn-primary:hover {' +
         '  background-color: #0069d9 !important;' +
-        '  border-color: #0069d9 !important;' +
+        '  border-color: #0062cc !important;' +
         '  transform: scale(1.05) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.4) !important;' +
         '}' +
@@ -431,9 +431,9 @@ const FilterControl = L.Control.extend({
       filterBtn.style.setProperty("padding-left", "12px", "important");
       filterBtn.style.setProperty("padding-right", "12px", "important");
       filterBtn.style.setProperty("line-height", "26px", "important");
-      filterBtn.style.setProperty("border", "1px solid", "important");
-      filterBtn.style.setProperty("border-color", "#007bff");
       filterBtn.style.setProperty("border-width", "1px", "important");
+      filterBtn.style.setProperty("border-style", "solid", "important");
+      filterBtn.style.setProperty("border-color", "#007bff");
       filterBtn.style.setProperty("box-sizing", "border-box", "important");
       filterBtn.style.setProperty("flex", "1 1 auto", "important");
       filterBtn.style.setProperty("align-self", "center", "important");
@@ -460,9 +460,9 @@ const FilterControl = L.Control.extend({
       clearBtn.style.setProperty("padding-left", "12px", "important");
       clearBtn.style.setProperty("padding-right", "12px", "important");
       clearBtn.style.setProperty("line-height", "26px", "important");
-      clearBtn.style.setProperty("border", "1px solid", "important");
-      clearBtn.style.setProperty("border-color", "#6c757d");
       clearBtn.style.setProperty("border-width", "1px", "important");
+      clearBtn.style.setProperty("border-style", "solid", "important");
+      clearBtn.style.setProperty("border-color", "#6c757d");
       clearBtn.style.setProperty("box-sizing", "border-box", "important");
       clearBtn.style.setProperty("flex", "1 1 auto", "important");
       clearBtn.style.setProperty("align-self", "center", "important");

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -263,6 +263,42 @@ const FilterControl = L.Control.extend({
     body.style.minHeight = "200px";
     body.style.maxHeight = "calc(80vh - 60px)"; // Account for header height
 
+    // Inject CSS once for sidebar button hover/active states.
+    // CSS :hover is more reliable than JS mouseenter listeners because it
+    // cannot be blocked by inline-style re-application or event timing.
+    if (!document.getElementById('smdb-sidebar-btn-css')) {
+      var sidebarBtnStyle = document.createElement('style');
+      sidebarBtnStyle.id = 'smdb-sidebar-btn-css';
+      sidebarBtnStyle.textContent =
+        '#filter-sidebar-body .btn-primary,' +
+        '#filter-sidebar-body .btn-secondary {' +
+        '  cursor: pointer !important;' +
+        '}' +
+        '#filter-sidebar-body .btn-primary {' +
+        '  transition: background-color 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +
+        '}' +
+        '#filter-sidebar-body .btn-secondary {' +
+        '  transition: background-color 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +
+        '}' +
+        '#filter-sidebar-body .btn-primary:hover {' +
+        '  background-color: #0069d9 !important;' +
+        '  transform: scale(1.05) !important;' +
+        '}' +
+        '#filter-sidebar-body .btn-primary:active {' +
+        '  background-color: #0062cc !important;' +
+        '  transform: scale(0.97) !important;' +
+        '}' +
+        '#filter-sidebar-body .btn-secondary:hover {' +
+        '  background-color: #5a6268 !important;' +
+        '  transform: scale(1.05) !important;' +
+        '}' +
+        '#filter-sidebar-body .btn-secondary:active {' +
+        '  background-color: #545b62 !important;' +
+        '  transform: scale(0.97) !important;' +
+        '}';
+      document.head.appendChild(sidebarBtnStyle);
+    }
+
     // -----------------------------------------------------------------------
     // recalcSidebarHeight — recompute sidebar height after a dropdown opens
     // or closes. Use natural height (auto) so collapsed content is measured
@@ -388,7 +424,9 @@ const FilterControl = L.Control.extend({
       filterBtn.style.setProperty("box-sizing", "border-box", "important");
       filterBtn.style.setProperty("flex", "1 1 auto", "important");
       filterBtn.style.setProperty("align-self", "center", "important");
-      
+      filterBtn.style.setProperty("cursor", "pointer", "important");
+      filterBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
+
       const clearBtn = document.createElement("button");
       clearBtn.type = "reset";
       clearBtn.id = filterType + "FilterCancel";
@@ -416,7 +454,35 @@ const FilterControl = L.Control.extend({
       clearBtn.style.setProperty("box-sizing", "border-box", "important");
       clearBtn.style.setProperty("flex", "1 1 auto", "important");
       clearBtn.style.setProperty("align-self", "center", "important");
-      
+      clearBtn.style.setProperty("cursor", "pointer", "important");
+      clearBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
+
+      // Hover / active feedback for both buttons
+      [
+        [filterBtn, "#0069d9", "#0062cc", "#0062cc"],
+        [clearBtn,  "#5a6268", "#545b62", "#545b62"],
+      ].forEach(function(args) {
+        var btn = args[0], hoverBg = args[1], hoverBorder = args[2], activeBg = args[3];
+        btn.addEventListener("mouseenter", function () {
+          this.style.setProperty("background-color", hoverBg, "important");
+          this.style.setProperty("border-color", hoverBorder, "important");
+          this.style.setProperty("transform", "scale(1.05)", "important");
+        });
+        btn.addEventListener("mouseleave", function () {
+          this.style.removeProperty("background-color");
+          this.style.removeProperty("border-color");
+          this.style.setProperty("transform", "scale(1)", "important");
+        });
+        btn.addEventListener("mousedown", function () {
+          this.style.setProperty("background-color", activeBg, "important");
+          this.style.setProperty("transform", "scale(0.97)", "important");
+        });
+        btn.addEventListener("mouseup", function () {
+          this.style.setProperty("background-color", hoverBg, "important");
+          this.style.setProperty("transform", "scale(1.05)", "important");
+        });
+      });
+
       buttonRow.appendChild(filterBtn);
       buttonRow.appendChild(clearBtn);
       clonedForm.appendChild(buttonRow);
@@ -463,15 +529,20 @@ const FilterControl = L.Control.extend({
             e.preventDefault();
             e.stopPropagation();
             e.stopImmediatePropagation();
-            
+
+            target.textContent = "Clearing\u2026";
+            target.style.setProperty("background-color", "#545b62", "important");
+            target.style.setProperty("cursor", "not-allowed", "important");
+
             // Store sidebar open state before reloading
-            sessionStorage.setItem('sidebarOpen', 'true');
-            
-            // Clear all filter parameters and reload current page
             const currentUrl = new URL(window.location.href);
             const filterKeys = ['name', 'region_name', 'vehicle_name', 'platformtype', 'quality_categories', 'patch_test', 'repeat_survey', 'mgds_compilation', 'expedition__name', 'citation', 'citation_search', 'filter_type', 'q', 'xmin', 'xmax', 'ymin', 'ymax', 'tmin', 'tmax'];
             filterKeys.forEach(key => currentUrl.searchParams.delete(key));
-            window.location.href = currentUrl.toString();
+            var clearUrl = currentUrl.toString();
+            setTimeout(function () {
+              sessionStorage.setItem('sidebarOpen', 'true');
+              window.location.href = clearUrl;
+            }, 80);
             return false;
           }
         }, true); // Capture phase - intercepts before onclick handlers
@@ -480,6 +551,13 @@ const FilterControl = L.Control.extend({
       // Add form submission handler to actually submit the form
       clonedForm.addEventListener("submit", function(e) {
         e.preventDefault(); // Prevent default submission
+        var submitBtn = clonedForm.querySelector('[id$="FilterSubmit"]') ||
+                        clonedForm.querySelector('[type="submit"]');
+        if (submitBtn) {
+          submitBtn.textContent = "Filtering\u2026";
+          submitBtn.style.setProperty("background-color", "#0062cc", "important");
+          submitBtn.style.setProperty("cursor", "not-allowed", "important");
+        }
         // Get form data
         const formData = new FormData(clonedForm);
         const params = new URLSearchParams(formData);
@@ -496,7 +574,10 @@ const FilterControl = L.Control.extend({
           }
         }
         // Reload page with filter parameters
-        window.location.href = currentUrl.toString();
+        var filterUrl = currentUrl.toString();
+        setTimeout(function () {
+          window.location.href = filterUrl;
+        }, 80);
       });
 
       const fieldCount = body.querySelectorAll(

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -461,32 +461,6 @@ const FilterControl = L.Control.extend({
       clearBtn.style.setProperty("cursor", "pointer", "important");
       clearBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 
-      // Hover / active feedback for both buttons
-      [
-        [filterBtn, "#0069d9", "#0062cc", "#0062cc"],
-        [clearBtn,  "#5a6268", "#545b62", "#545b62"],
-      ].forEach(function(args) {
-        var btn = args[0], hoverBg = args[1], hoverBorder = args[2], activeBg = args[3];
-        btn.addEventListener("mouseenter", function () {
-          this.style.setProperty("background-color", hoverBg, "important");
-          this.style.setProperty("border-color", hoverBorder, "important");
-          this.style.setProperty("transform", "scale(1.05)", "important");
-        });
-        btn.addEventListener("mouseleave", function () {
-          this.style.removeProperty("background-color");
-          this.style.removeProperty("border-color");
-          this.style.setProperty("transform", "scale(1)", "important");
-        });
-        btn.addEventListener("mousedown", function () {
-          this.style.setProperty("background-color", activeBg, "important");
-          this.style.setProperty("transform", "scale(0.97)", "important");
-        });
-        btn.addEventListener("mouseup", function () {
-          this.style.setProperty("background-color", hoverBg, "important");
-          this.style.setProperty("transform", "scale(1.05)", "important");
-        });
-      });
-
       buttonRow.appendChild(filterBtn);
       buttonRow.appendChild(clearBtn);
       clonedForm.appendChild(buttonRow);
@@ -533,18 +507,21 @@ const FilterControl = L.Control.extend({
             e.preventDefault();
             e.stopPropagation();
             e.stopImmediatePropagation();
+            if (target.dataset.clearing === "true") { return false; }
+            target.dataset.clearing = "true";
 
             target.textContent = "Clearing\u2026";
             target.style.setProperty("background-color", "#545b62", "important");
             target.style.setProperty("cursor", "not-allowed", "important");
+            target.disabled = true;
+            target.setAttribute("aria-disabled", "true");
 
-            // Store sidebar open state before reloading
             const currentUrl = new URL(window.location.href);
             const filterKeys = ['name', 'region_name', 'vehicle_name', 'platformtype', 'quality_categories', 'patch_test', 'repeat_survey', 'mgds_compilation', 'expedition__name', 'citation', 'citation_search', 'filter_type', 'q', 'xmin', 'xmax', 'ymin', 'ymax', 'tmin', 'tmax'];
             filterKeys.forEach(key => currentUrl.searchParams.delete(key));
             var clearUrl = currentUrl.toString();
+            sessionStorage.setItem('sidebarOpen', 'true');
             setTimeout(function () {
-              sessionStorage.setItem('sidebarOpen', 'true');
               window.location.href = clearUrl;
             }, 80);
             return false;
@@ -555,12 +532,16 @@ const FilterControl = L.Control.extend({
       // Add form submission handler to actually submit the form
       clonedForm.addEventListener("submit", function(e) {
         e.preventDefault(); // Prevent default submission
+        if (clonedForm.dataset.submitting === "true") { return false; }
+        clonedForm.dataset.submitting = "true";
         var submitBtn = clonedForm.querySelector('[id$="FilterSubmit"]') ||
                         clonedForm.querySelector('[type="submit"]');
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
           submitBtn.style.setProperty("cursor", "not-allowed", "important");
+          submitBtn.disabled = true;
+          submitBtn.setAttribute("aria-disabled", "true");
         }
         // Get form data
         const formData = new FormData(clonedForm);

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -280,28 +280,32 @@ const FilterControl = L.Control.extend({
         '  cursor: default;' +
         '}' +
         '#filter-sidebar-body .btn-primary {' +
-        '  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +
+        '  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +
         '}' +
         '#filter-sidebar-body .btn-secondary {' +
-        '  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +
+        '  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +
         '}' +
         '#filter-sidebar-body .btn-primary:hover {' +
         '  background-color: #0069d9 !important;' +
+        '  border-color: #0069d9 !important;' +
         '  transform: scale(1.05) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.4) !important;' +
         '}' +
         '#filter-sidebar-body .btn-primary:active {' +
         '  background-color: #0062cc !important;' +
+        '  border-color: #0062cc !important;' +
         '  transform: scale(0.97) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5) !important;' +
         '}' +
         '#filter-sidebar-body .btn-secondary:hover {' +
         '  background-color: #5a6268 !important;' +
+        '  border-color: #5a6268 !important;' +
         '  transform: scale(1.05) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.4) !important;' +
         '}' +
         '#filter-sidebar-body .btn-secondary:active {' +
         '  background-color: #545b62 !important;' +
+        '  border-color: #545b62 !important;' +
         '  transform: scale(0.97) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5) !important;' +
         '}';
@@ -428,12 +432,12 @@ const FilterControl = L.Control.extend({
       filterBtn.style.setProperty("padding-right", "12px", "important");
       filterBtn.style.setProperty("line-height", "26px", "important");
       filterBtn.style.setProperty("border", "1px solid", "important");
-      filterBtn.style.setProperty("border-color", "#007bff", "important");
+      filterBtn.style.setProperty("border-color", "#007bff");
       filterBtn.style.setProperty("border-width", "1px", "important");
       filterBtn.style.setProperty("box-sizing", "border-box", "important");
       filterBtn.style.setProperty("flex", "1 1 auto", "important");
       filterBtn.style.setProperty("align-self", "center", "important");
-      filterBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
+      filterBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 
       const clearBtn = document.createElement("button");
       clearBtn.type = "reset";
@@ -457,12 +461,12 @@ const FilterControl = L.Control.extend({
       clearBtn.style.setProperty("padding-right", "12px", "important");
       clearBtn.style.setProperty("line-height", "26px", "important");
       clearBtn.style.setProperty("border", "1px solid", "important");
-      clearBtn.style.setProperty("border-color", "#6c757d", "important");
+      clearBtn.style.setProperty("border-color", "#6c757d");
       clearBtn.style.setProperty("border-width", "1px", "important");
       clearBtn.style.setProperty("box-sizing", "border-box", "important");
       clearBtn.style.setProperty("flex", "1 1 auto", "important");
       clearBtn.style.setProperty("align-self", "center", "important");
-      clearBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
+      clearBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 
       buttonRow.appendChild(filterBtn);
       buttonRow.appendChild(clearBtn);

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -280,28 +280,32 @@ const FilterControl = L.Control.extend({
         '  cursor: default;' +
         '}' +
         '#filter-sidebar-body .btn-primary {' +
-        '  transition: background-color 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +
+        '  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +
         '}' +
         '#filter-sidebar-body .btn-secondary {' +
-        '  transition: background-color 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +
+        '  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out !important;' +
         '}' +
         '#filter-sidebar-body .btn-primary:hover {' +
         '  background-color: #0069d9 !important;' +
+        '  border-color: #0062cc !important;' +
         '  transform: scale(1.05) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.4) !important;' +
         '}' +
         '#filter-sidebar-body .btn-primary:active {' +
         '  background-color: #0062cc !important;' +
+        '  border-color: #005cbf !important;' +
         '  transform: scale(0.97) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5) !important;' +
         '}' +
         '#filter-sidebar-body .btn-secondary:hover {' +
         '  background-color: #5a6268 !important;' +
+        '  border-color: #545b62 !important;' +
         '  transform: scale(1.05) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.4) !important;' +
         '}' +
         '#filter-sidebar-body .btn-secondary:active {' +
         '  background-color: #545b62 !important;' +
+        '  border-color: #4e555b !important;' +
         '  transform: scale(0.97) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5) !important;' +
         '}';
@@ -433,7 +437,7 @@ const FilterControl = L.Control.extend({
       filterBtn.style.setProperty("box-sizing", "border-box", "important");
       filterBtn.style.setProperty("flex", "1 1 auto", "important");
       filterBtn.style.setProperty("align-self", "center", "important");
-      filterBtn.style.setProperty("cursor", "pointer", "important");
+      filterBtn.style.setProperty("cursor", "pointer");
       filterBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 
       const clearBtn = document.createElement("button");
@@ -463,7 +467,7 @@ const FilterControl = L.Control.extend({
       clearBtn.style.setProperty("box-sizing", "border-box", "important");
       clearBtn.style.setProperty("flex", "1 1 auto", "important");
       clearBtn.style.setProperty("align-self", "center", "important");
-      clearBtn.style.setProperty("cursor", "pointer", "important");
+      clearBtn.style.setProperty("cursor", "pointer");
       clearBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 
       buttonRow.appendChild(filterBtn);
@@ -517,6 +521,7 @@ const FilterControl = L.Control.extend({
 
             target.textContent = "Clearing\u2026";
             target.style.setProperty("background-color", "#545b62", "important");
+            target.style.setProperty("border-color", "#545b62", "important");
             target.disabled = true;
             target.setAttribute("aria-disabled", "true");
 
@@ -543,6 +548,7 @@ const FilterControl = L.Control.extend({
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
+          submitBtn.style.setProperty("border-color", "#0062cc", "important");
           submitBtn.disabled = true;
           submitBtn.setAttribute("aria-disabled", "true");
         }

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -283,18 +283,22 @@ const FilterControl = L.Control.extend({
         '#filter-sidebar-body .btn-primary:hover {' +
         '  background-color: #0069d9 !important;' +
         '  transform: scale(1.05) !important;' +
+        '  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.4) !important;' +
         '}' +
         '#filter-sidebar-body .btn-primary:active {' +
         '  background-color: #0062cc !important;' +
         '  transform: scale(0.97) !important;' +
+        '  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5) !important;' +
         '}' +
         '#filter-sidebar-body .btn-secondary:hover {' +
         '  background-color: #5a6268 !important;' +
         '  transform: scale(1.05) !important;' +
+        '  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.4) !important;' +
         '}' +
         '#filter-sidebar-body .btn-secondary:active {' +
         '  background-color: #545b62 !important;' +
         '  transform: scale(0.97) !important;' +
+        '  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5) !important;' +
         '}';
       document.head.appendChild(sidebarBtnStyle);
     }

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -512,7 +512,6 @@ const FilterControl = L.Control.extend({
 
             target.textContent = "Clearing\u2026";
             target.style.setProperty("background-color", "#545b62", "important");
-            target.style.setProperty("cursor", "not-allowed", "important");
             target.disabled = true;
             target.setAttribute("aria-disabled", "true");
 
@@ -539,7 +538,6 @@ const FilterControl = L.Control.extend({
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
-          submitBtn.style.setProperty("cursor", "not-allowed", "important");
           submitBtn.disabled = true;
           submitBtn.setAttribute("aria-disabled", "true");
         }

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -913,10 +913,6 @@ const FilterControl = L.Control.extend({
       // Style buttons - find ALL buttons, not just .btn class
       // Make sure to include buttons we just created
       const allButtons = body.querySelectorAll("button");
-      console.log("Found buttons:", allButtons.length);
-      console.log("Button row exists:", body.querySelector(".button-row"));
-      console.log("Filter button exists:", body.querySelector("button[type='submit']"));
-      console.log("Clear button exists:", body.querySelector("button[type='reset']"));
       allButtons.forEach((btn) => {
         // Ensure button is visible
         btn.style.display = "block";
@@ -1239,13 +1235,10 @@ const FilterControl = L.Control.extend({
     const maxRetries = 10;
     const tryCopyForm = function () {
       if (copyForm(currentFilterType)) {
-        console.log(`Form successfully copied to sidebar (${currentFilterType})`);
+        // form copied successfully
       } else {
         retryCount++;
         if (retryCount < maxRetries) {
-          console.log(
-            `Retrying form copy (attempt ${retryCount}/${maxRetries})...`
-          );
           setTimeout(tryCopyForm, 300);
         } else {
           console.error("Failed to copy form after", maxRetries, "attempts");
@@ -1617,16 +1610,13 @@ map.whenReady(function() {
       // Get the zoom level that fitBounds calculated
       var calculatedZoom = map.getZoom();
       var finalCenter = map.getCenter();
-      console.log("Current map zoom level:", calculatedZoom);
-      console.log("Map center (Lat, Lng):", finalCenter.lat.toFixed(4), ",", finalCenter.lng.toFixed(4));
-      console.log("Mission bounds center (Lat, Lng):", ((sw.lat + ne.lat) / 2).toFixed(4), ",", ((sw.lng + ne.lng) / 2).toFixed(4));
-      
+
       // Allow fractional zoom for finer control when zooming in
       // No constraint on zooming out - let fitBounds determine optimal zoom to show all missions
       // Fractional zoom (0.5 increments) allows more precise zoom levels when user zooms in
     } catch (err) {
       // If getBounds fails (e.g., no features), set to default zoom level 3 and center
-      console.log("Error fitting bounds: " + err.message);
+      console.error("Error fitting bounds: " + err.message);
       map.setView([39.8423, -26.8945], 3, { animate: false });
     }
   }, 150);
@@ -1713,30 +1703,18 @@ setTimeout(function() {
       var adjustedLat = missionCenterLat - (ne.lat - missionCenterLat) * 0.1; // Shift 10% of upper half southward
       map.setView([adjustedLat, currentCenter.lng], map.getZoom(), { animate: false });
     }
-    
     // Log the zoom level after fitBounds in fallback setTimeout
     var finalZoom = map.getZoom();
     var finalCenterFallback = map.getCenter();
-    console.log("Current map zoom level (fallback setTimeout):", finalZoom);
-    console.log("Map center (Lat, Lng) - fallback:", finalCenterFallback.lat.toFixed(4), ",", finalCenterFallback.lng.toFixed(4));
-    console.log("Mission bounds center (Lat, Lng) - fallback:", ((sw.lat + ne.lat) / 2).toFixed(4), ",", ((sw.lng + ne.lng) / 2).toFixed(4));
-    
+
     // Fractional zoom enabled - allows 0.5 increments for finer zoom control
     // No zoom constraint - fitBounds determines optimal zoom to show all missions
   } catch (err) {
     // If getBounds fails (e.g., no features), set to default zoom level 3 and center
-    console.log("Error in fallback fitBounds: " + err.message);
+    console.error("Error in fallback fitBounds: " + err.message);
     map.setView([39.8423, -26.8945], 3, { animate: false });
   }
 }, 100);
-
-// Log final zoom level and center after all initialization is complete
-setTimeout(function() {
-  var finalZoomLevel = map.getZoom();
-  var finalMapCenter = map.getCenter();
-  console.log("=== FINAL MAP ZOOM LEVEL:", finalZoomLevel, "===");
-  console.log("=== FINAL MAP CENTER (Lat, Lng):", finalMapCenter.lat.toFixed(4), ",", finalMapCenter.lng.toFixed(4), "===");
-}, 500);
 
 /* --------------------------------------------------  */
 // Set up SIDEBAR
@@ -1981,7 +1959,6 @@ function styleDrawSquareControl() {
   const controlContainer = drawSquareButton.getContainer();
   
   if (!controlContainer) {
-    console.log("Control container not found, retrying...");
     setTimeout(styleDrawSquareControl, 100);
     return;
   }
@@ -2014,11 +1991,7 @@ function styleDrawSquareControl() {
     // Add a class and ID for CSS targeting
     leafletControlDiv.classList.add("draw-square-control-wrapper");
     leafletControlDiv.id = "draw-square-control-wrapper";
-    console.log("Applied styles to draw square control wrapper");
-    console.log("Current margin-left:", leafletControlDiv.style.marginLeft);
-    console.log("Computed margin-left:", window.getComputedStyle(leafletControlDiv).marginLeft);
   } else {
-    console.log("Could not find .leaflet-control wrapper, retrying...");
     setTimeout(styleDrawSquareControl, 100);
   }
 }
@@ -2494,7 +2467,6 @@ L.Control.Layers.include({
     this._groupedLayers.forEach(function (obj) {
       // Check if it's an overlay and added to the map
       if (obj.overlay && this._map.hasLayer(obj.layer)) {
-        console.log("OBJECT OVERLAY");
         // Push layer to active array
         active.push(obj.layer);
       }

--- a/smdb/smdb/static/js/map.js
+++ b/smdb/smdb/static/js/map.js
@@ -287,25 +287,21 @@ const FilterControl = L.Control.extend({
         '}' +
         '#filter-sidebar-body .btn-primary:hover {' +
         '  background-color: #0069d9 !important;' +
-        '  border-color: #0062cc !important;' +
         '  transform: scale(1.05) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.4) !important;' +
         '}' +
         '#filter-sidebar-body .btn-primary:active {' +
         '  background-color: #0062cc !important;' +
-        '  border-color: #005cbf !important;' +
         '  transform: scale(0.97) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5) !important;' +
         '}' +
         '#filter-sidebar-body .btn-secondary:hover {' +
         '  background-color: #5a6268 !important;' +
-        '  border-color: #545b62 !important;' +
         '  transform: scale(1.05) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.4) !important;' +
         '}' +
         '#filter-sidebar-body .btn-secondary:active {' +
         '  background-color: #545b62 !important;' +
-        '  border-color: #4e555b !important;' +
         '  transform: scale(0.97) !important;' +
         '  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5) !important;' +
         '}';
@@ -437,7 +433,6 @@ const FilterControl = L.Control.extend({
       filterBtn.style.setProperty("box-sizing", "border-box", "important");
       filterBtn.style.setProperty("flex", "1 1 auto", "important");
       filterBtn.style.setProperty("align-self", "center", "important");
-      filterBtn.style.setProperty("cursor", "pointer");
       filterBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 
       const clearBtn = document.createElement("button");
@@ -467,7 +462,6 @@ const FilterControl = L.Control.extend({
       clearBtn.style.setProperty("box-sizing", "border-box", "important");
       clearBtn.style.setProperty("flex", "1 1 auto", "important");
       clearBtn.style.setProperty("align-self", "center", "important");
-      clearBtn.style.setProperty("cursor", "pointer");
       clearBtn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 
       buttonRow.appendChild(filterBtn);

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -401,6 +401,7 @@ const FilterControl = L.Control.extend({
       filterBtn.className = "btn btn-primary";
       filterBtn.textContent = "Filter";
       _styleBtn(filterBtn, "#007bff");
+      _addBtnHoverFeedback(filterBtn, "#0069d9", "#0062cc", "#0062cc");
 
       const clearBtn = document.createElement("button");
       clearBtn.type = "reset";
@@ -408,6 +409,7 @@ const FilterControl = L.Control.extend({
       clearBtn.className = "btn btn-secondary";
       clearBtn.textContent = "Clear";
       _styleBtn(clearBtn, "#6c757d");
+      _addBtnHoverFeedback(clearBtn, "#5a6268", "#545b62", "#545b62");
 
       buttonRow.appendChild(filterBtn);
       buttonRow.appendChild(clearBtn);
@@ -435,12 +437,18 @@ const FilterControl = L.Control.extend({
               e.preventDefault();
               e.stopPropagation();
               e.stopImmediatePropagation();
-              sessionStorage.setItem("sidebarOpen", "true");
+              tgt.textContent = "Clearing\u2026";
+              tgt.style.setProperty("background-color", "#545b62", "important");
+              tgt.style.setProperty("cursor", "not-allowed", "important");
               var url = new URL(window.location.href);
               ["name", "filter_type", "xmin", "xmax", "ymin", "ymax"].forEach(function (k) {
                 url.searchParams.delete(k);
               });
-              window.location.href = url.toString();
+              var clearUrl = url.toString();
+              setTimeout(function () {
+                sessionStorage.setItem("sidebarOpen", "true");
+                window.location.href = clearUrl;
+              }, 80);
               return false;
             }
           },
@@ -450,13 +458,23 @@ const FilterControl = L.Control.extend({
 
       clonedForm.addEventListener("submit", function (e) {
         e.preventDefault();
+        var submitBtn = clonedForm.querySelector('[id$="FilterSubmit"]') ||
+                        clonedForm.querySelector('[type="submit"]');
+        if (submitBtn) {
+          submitBtn.textContent = "Filtering\u2026";
+          submitBtn.style.setProperty("background-color", "#0062cc", "important");
+          submitBtn.style.setProperty("cursor", "not-allowed", "important");
+        }
         var params = new URLSearchParams(new FormData(clonedForm));
         var url = new URL(window.location.href);
         ["name", "filter_type"].forEach(function (k) { url.searchParams.delete(k); });
         params.forEach(function (val, key) {
           if (val) url.searchParams.append(key, val);
         });
-        window.location.href = url.toString();
+        var filterUrl = url.toString();
+        setTimeout(function () {
+          window.location.href = filterUrl;
+        }, 80);
       });
 
       body
@@ -874,4 +892,27 @@ function _styleBtn(btn, borderColor) {
   btn.style.setProperty("box-sizing", "border-box", "important");
   btn.style.setProperty("flex", "1 1 auto", "important");
   btn.style.setProperty("align-self", "center", "important");
+  btn.style.setProperty("cursor", "pointer", "important");
+  btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
+}
+
+function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
+  btn.addEventListener("mouseenter", function () {
+    this.style.setProperty("background-color", hoverBg, "important");
+    this.style.setProperty("border-color", hoverBorder, "important");
+    this.style.setProperty("transform", "scale(1.05)", "important");
+  });
+  btn.addEventListener("mouseleave", function () {
+    this.style.removeProperty("background-color");
+    this.style.removeProperty("border-color");
+    this.style.setProperty("transform", "scale(1)", "important");
+  });
+  btn.addEventListener("mousedown", function () {
+    this.style.setProperty("background-color", activeBg, "important");
+    this.style.setProperty("transform", "scale(0.97)", "important");
+  });
+  btn.addEventListener("mouseup", function () {
+    this.style.setProperty("background-color", hoverBg, "important");
+    this.style.setProperty("transform", "scale(1.05)", "important");
+  });
 }

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -898,37 +898,6 @@ function _styleBtn(btn, borderColor) {
   btn.style.setProperty("box-sizing", "border-box", "important");
   btn.style.setProperty("flex", "1 1 auto", "important");
   btn.style.setProperty("align-self", "center", "important");
-  btn.style.setProperty("cursor", "pointer", "important");
   btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 }
 
-function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
-  var shadowColor = btn.classList.contains("btn-primary")
-    ? "rgba(0, 123, 255, 0.4)"
-    : "rgba(108, 117, 125, 0.4)";
-  var shadowColorActive = btn.classList.contains("btn-primary")
-    ? "rgba(0, 123, 255, 0.5)"
-    : "rgba(108, 117, 125, 0.5)";
-  btn.addEventListener("mouseenter", function () {
-    this.style.setProperty("background-color", hoverBg, "important");
-    this.style.setProperty("border-color", hoverBorder, "important");
-    this.style.setProperty("transform", "scale(1.05)", "important");
-    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
-  });
-  btn.addEventListener("mouseleave", function () {
-    this.style.removeProperty("background-color");
-    this.style.removeProperty("border-color");
-    this.style.setProperty("transform", "scale(1)", "important");
-    this.style.removeProperty("box-shadow");
-  });
-  btn.addEventListener("mousedown", function () {
-    this.style.setProperty("background-color", activeBg, "important");
-    this.style.setProperty("transform", "scale(0.97)", "important");
-    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColorActive, "important");
-  });
-  btn.addEventListener("mouseup", function () {
-    this.style.setProperty("background-color", hoverBg, "important");
-    this.style.setProperty("transform", "scale(1.05)", "important");
-    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
-  });
-}

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -437,16 +437,20 @@ const FilterControl = L.Control.extend({
               e.preventDefault();
               e.stopPropagation();
               e.stopImmediatePropagation();
+              if (tgt.dataset.clearing === "true") { return false; }
+              tgt.dataset.clearing = "true";
               tgt.textContent = "Clearing\u2026";
               tgt.style.setProperty("background-color", "#545b62", "important");
               tgt.style.setProperty("cursor", "not-allowed", "important");
+              tgt.disabled = true;
+              tgt.setAttribute("aria-disabled", "true");
               var url = new URL(window.location.href);
               ["name", "filter_type", "xmin", "xmax", "ymin", "ymax"].forEach(function (k) {
                 url.searchParams.delete(k);
               });
               var clearUrl = url.toString();
+              sessionStorage.setItem("sidebarOpen", "true");
               setTimeout(function () {
-                sessionStorage.setItem("sidebarOpen", "true");
                 window.location.href = clearUrl;
               }, 80);
               return false;
@@ -458,12 +462,16 @@ const FilterControl = L.Control.extend({
 
       clonedForm.addEventListener("submit", function (e) {
         e.preventDefault();
+        if (clonedForm.dataset.submitting === "true") { return false; }
+        clonedForm.dataset.submitting = "true";
         var submitBtn = clonedForm.querySelector('[id$="FilterSubmit"]') ||
                         clonedForm.querySelector('[type="submit"]');
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
           submitBtn.style.setProperty("cursor", "not-allowed", "important");
+          submitBtn.disabled = true;
+          submitBtn.setAttribute("aria-disabled", "true");
         }
         var params = new URLSearchParams(new FormData(clonedForm));
         var url = new URL(window.location.href);

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -401,7 +401,7 @@ const FilterControl = L.Control.extend({
       filterBtn.className = "btn btn-primary";
       filterBtn.textContent = "Filter";
       _styleBtn(filterBtn, "#007bff");
-      _addBtnHoverFeedback(filterBtn, "#0069d9", "#0062cc", "#0062cc");
+      addBtnHoverFeedback(filterBtn, "#0069d9", "#0062cc", "#0062cc");
 
       const clearBtn = document.createElement("button");
       clearBtn.type = "reset";
@@ -409,7 +409,7 @@ const FilterControl = L.Control.extend({
       clearBtn.className = "btn btn-secondary";
       clearBtn.textContent = "Clear";
       _styleBtn(clearBtn, "#6c757d");
-      _addBtnHoverFeedback(clearBtn, "#5a6268", "#545b62", "#545b62");
+      addBtnHoverFeedback(clearBtn, "#5a6268", "#545b62", "#545b62");
 
       buttonRow.appendChild(filterBtn);
       buttonRow.appendChild(clearBtn);
@@ -441,6 +441,7 @@ const FilterControl = L.Control.extend({
               tgt.dataset.clearing = "true";
               tgt.textContent = "Clearing\u2026";
               tgt.style.setProperty("background-color", "#545b62", "important");
+              tgt.style.setProperty("border-color", "#545b62", "important");
               tgt.disabled = true;
               tgt.setAttribute("aria-disabled", "true");
               var url = new URL(window.location.href);
@@ -468,6 +469,7 @@ const FilterControl = L.Control.extend({
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
+          submitBtn.style.setProperty("border-color", "#0062cc", "important");
           submitBtn.disabled = true;
           submitBtn.setAttribute("aria-disabled", "true");
         }

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -900,6 +900,6 @@ function _styleBtn(btn, borderColor) {
   btn.style.setProperty("box-sizing", "border-box", "important");
   btn.style.setProperty("flex", "1 1 auto", "important");
   btn.style.setProperty("align-self", "center", "important");
-  btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
+  btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 }
 

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -441,7 +441,6 @@ const FilterControl = L.Control.extend({
               tgt.dataset.clearing = "true";
               tgt.textContent = "Clearing\u2026";
               tgt.style.setProperty("background-color", "#545b62", "important");
-              tgt.style.setProperty("cursor", "not-allowed", "important");
               tgt.disabled = true;
               tgt.setAttribute("aria-disabled", "true");
               var url = new URL(window.location.href);
@@ -469,7 +468,6 @@ const FilterControl = L.Control.extend({
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
-          submitBtn.style.setProperty("cursor", "not-allowed", "important");
           submitBtn.disabled = true;
           submitBtn.setAttribute("aria-disabled", "true");
         }

--- a/smdb/smdb/static/js/map_compilation_filter.js
+++ b/smdb/smdb/static/js/map_compilation_filter.js
@@ -897,22 +897,32 @@ function _styleBtn(btn, borderColor) {
 }
 
 function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
+  var shadowColor = btn.classList.contains("btn-primary")
+    ? "rgba(0, 123, 255, 0.4)"
+    : "rgba(108, 117, 125, 0.4)";
+  var shadowColorActive = btn.classList.contains("btn-primary")
+    ? "rgba(0, 123, 255, 0.5)"
+    : "rgba(108, 117, 125, 0.5)";
   btn.addEventListener("mouseenter", function () {
     this.style.setProperty("background-color", hoverBg, "important");
     this.style.setProperty("border-color", hoverBorder, "important");
     this.style.setProperty("transform", "scale(1.05)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
   });
   btn.addEventListener("mouseleave", function () {
     this.style.removeProperty("background-color");
     this.style.removeProperty("border-color");
     this.style.setProperty("transform", "scale(1)", "important");
+    this.style.removeProperty("box-shadow");
   });
   btn.addEventListener("mousedown", function () {
     this.style.setProperty("background-color", activeBg, "important");
     this.style.setProperty("transform", "scale(0.97)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColorActive, "important");
   });
   btn.addEventListener("mouseup", function () {
     this.style.setProperty("background-color", hoverBg, "important");
     this.style.setProperty("transform", "scale(1.05)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
   });
 }

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -401,6 +401,7 @@ const FilterControl = L.Control.extend({
       filterBtn.className = "btn btn-primary";
       filterBtn.textContent = "Filter";
       _styleBtn(filterBtn, "#007bff");
+      _addBtnHoverFeedback(filterBtn, "#0069d9", "#0062cc", "#0062cc");
 
       const clearBtn = document.createElement("button");
       clearBtn.type = "reset";
@@ -408,6 +409,7 @@ const FilterControl = L.Control.extend({
       clearBtn.className = "btn btn-secondary";
       clearBtn.textContent = "Clear";
       _styleBtn(clearBtn, "#6c757d");
+      _addBtnHoverFeedback(clearBtn, "#5a6268", "#545b62", "#545b62");
 
       buttonRow.appendChild(filterBtn);
       buttonRow.appendChild(clearBtn);
@@ -435,12 +437,18 @@ const FilterControl = L.Control.extend({
               e.preventDefault();
               e.stopPropagation();
               e.stopImmediatePropagation();
-              sessionStorage.setItem("sidebarOpen", "true");
+              tgt.textContent = "Clearing\u2026";
+              tgt.style.setProperty("background-color", "#545b62", "important");
+              tgt.style.setProperty("cursor", "not-allowed", "important");
               var url = new URL(window.location.href);
               ["name", "filter_type", "xmin", "xmax", "ymin", "ymax"].forEach(function (k) {
                 url.searchParams.delete(k);
               });
-              window.location.href = url.toString();
+              var clearUrl = url.toString();
+              setTimeout(function () {
+                sessionStorage.setItem("sidebarOpen", "true");
+                window.location.href = clearUrl;
+              }, 80);
               return false;
             }
           },
@@ -450,13 +458,23 @@ const FilterControl = L.Control.extend({
 
       clonedForm.addEventListener("submit", function (e) {
         e.preventDefault();
+        var submitBtn = clonedForm.querySelector('[id$="FilterSubmit"]') ||
+                        clonedForm.querySelector('[type="submit"]');
+        if (submitBtn) {
+          submitBtn.textContent = "Filtering\u2026";
+          submitBtn.style.setProperty("background-color", "#0062cc", "important");
+          submitBtn.style.setProperty("cursor", "not-allowed", "important");
+        }
         var params = new URLSearchParams(new FormData(clonedForm));
         var url = new URL(window.location.href);
         ["name", "filter_type"].forEach(function (k) { url.searchParams.delete(k); });
         params.forEach(function (val, key) {
           if (val) url.searchParams.append(key, val);
         });
-        window.location.href = url.toString();
+        var filterUrl = url.toString();
+        setTimeout(function () {
+          window.location.href = filterUrl;
+        }, 80);
       });
 
       body
@@ -874,4 +892,27 @@ function _styleBtn(btn, borderColor) {
   btn.style.setProperty("box-sizing", "border-box", "important");
   btn.style.setProperty("flex", "1 1 auto", "important");
   btn.style.setProperty("align-self", "center", "important");
+  btn.style.setProperty("cursor", "pointer", "important");
+  btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
+}
+
+function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
+  btn.addEventListener("mouseenter", function () {
+    this.style.setProperty("background-color", hoverBg, "important");
+    this.style.setProperty("border-color", hoverBorder, "important");
+    this.style.setProperty("transform", "scale(1.05)", "important");
+  });
+  btn.addEventListener("mouseleave", function () {
+    this.style.removeProperty("background-color");
+    this.style.removeProperty("border-color");
+    this.style.setProperty("transform", "scale(1)", "important");
+  });
+  btn.addEventListener("mousedown", function () {
+    this.style.setProperty("background-color", activeBg, "important");
+    this.style.setProperty("transform", "scale(0.97)", "important");
+  });
+  btn.addEventListener("mouseup", function () {
+    this.style.setProperty("background-color", hoverBg, "important");
+    this.style.setProperty("transform", "scale(1.05)", "important");
+  });
 }

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -898,37 +898,6 @@ function _styleBtn(btn, borderColor) {
   btn.style.setProperty("box-sizing", "border-box", "important");
   btn.style.setProperty("flex", "1 1 auto", "important");
   btn.style.setProperty("align-self", "center", "important");
-  btn.style.setProperty("cursor", "pointer", "important");
   btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 }
 
-function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
-  var shadowColor = btn.classList.contains("btn-primary")
-    ? "rgba(0, 123, 255, 0.4)"
-    : "rgba(108, 117, 125, 0.4)";
-  var shadowColorActive = btn.classList.contains("btn-primary")
-    ? "rgba(0, 123, 255, 0.5)"
-    : "rgba(108, 117, 125, 0.5)";
-  btn.addEventListener("mouseenter", function () {
-    this.style.setProperty("background-color", hoverBg, "important");
-    this.style.setProperty("border-color", hoverBorder, "important");
-    this.style.setProperty("transform", "scale(1.05)", "important");
-    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
-  });
-  btn.addEventListener("mouseleave", function () {
-    this.style.removeProperty("background-color");
-    this.style.removeProperty("border-color");
-    this.style.setProperty("transform", "scale(1)", "important");
-    this.style.removeProperty("box-shadow");
-  });
-  btn.addEventListener("mousedown", function () {
-    this.style.setProperty("background-color", activeBg, "important");
-    this.style.setProperty("transform", "scale(0.97)", "important");
-    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColorActive, "important");
-  });
-  btn.addEventListener("mouseup", function () {
-    this.style.setProperty("background-color", hoverBg, "important");
-    this.style.setProperty("transform", "scale(1.05)", "important");
-    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
-  });
-}

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -437,16 +437,20 @@ const FilterControl = L.Control.extend({
               e.preventDefault();
               e.stopPropagation();
               e.stopImmediatePropagation();
+              if (tgt.dataset.clearing === "true") { return false; }
+              tgt.dataset.clearing = "true";
               tgt.textContent = "Clearing\u2026";
               tgt.style.setProperty("background-color", "#545b62", "important");
               tgt.style.setProperty("cursor", "not-allowed", "important");
+              tgt.disabled = true;
+              tgt.setAttribute("aria-disabled", "true");
               var url = new URL(window.location.href);
               ["name", "filter_type", "xmin", "xmax", "ymin", "ymax"].forEach(function (k) {
                 url.searchParams.delete(k);
               });
               var clearUrl = url.toString();
+              sessionStorage.setItem("sidebarOpen", "true");
               setTimeout(function () {
-                sessionStorage.setItem("sidebarOpen", "true");
                 window.location.href = clearUrl;
               }, 80);
               return false;
@@ -458,12 +462,16 @@ const FilterControl = L.Control.extend({
 
       clonedForm.addEventListener("submit", function (e) {
         e.preventDefault();
+        if (clonedForm.dataset.submitting === "true") { return false; }
+        clonedForm.dataset.submitting = "true";
         var submitBtn = clonedForm.querySelector('[id$="FilterSubmit"]') ||
                         clonedForm.querySelector('[type="submit"]');
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
           submitBtn.style.setProperty("cursor", "not-allowed", "important");
+          submitBtn.disabled = true;
+          submitBtn.setAttribute("aria-disabled", "true");
         }
         var params = new URLSearchParams(new FormData(clonedForm));
         var url = new URL(window.location.href);

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -401,7 +401,7 @@ const FilterControl = L.Control.extend({
       filterBtn.className = "btn btn-primary";
       filterBtn.textContent = "Filter";
       _styleBtn(filterBtn, "#007bff");
-      _addBtnHoverFeedback(filterBtn, "#0069d9", "#0062cc", "#0062cc");
+      addBtnHoverFeedback(filterBtn, "#0069d9", "#0062cc", "#0062cc");
 
       const clearBtn = document.createElement("button");
       clearBtn.type = "reset";
@@ -409,7 +409,7 @@ const FilterControl = L.Control.extend({
       clearBtn.className = "btn btn-secondary";
       clearBtn.textContent = "Clear";
       _styleBtn(clearBtn, "#6c757d");
-      _addBtnHoverFeedback(clearBtn, "#5a6268", "#545b62", "#545b62");
+      addBtnHoverFeedback(clearBtn, "#5a6268", "#545b62", "#545b62");
 
       buttonRow.appendChild(filterBtn);
       buttonRow.appendChild(clearBtn);
@@ -441,6 +441,7 @@ const FilterControl = L.Control.extend({
               tgt.dataset.clearing = "true";
               tgt.textContent = "Clearing\u2026";
               tgt.style.setProperty("background-color", "#545b62", "important");
+              tgt.style.setProperty("border-color", "#545b62", "important");
               tgt.disabled = true;
               tgt.setAttribute("aria-disabled", "true");
               var url = new URL(window.location.href);
@@ -468,6 +469,7 @@ const FilterControl = L.Control.extend({
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
+          submitBtn.style.setProperty("border-color", "#0062cc", "important");
           submitBtn.disabled = true;
           submitBtn.setAttribute("aria-disabled", "true");
         }

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -900,6 +900,6 @@ function _styleBtn(btn, borderColor) {
   btn.style.setProperty("box-sizing", "border-box", "important");
   btn.style.setProperty("flex", "1 1 auto", "important");
   btn.style.setProperty("align-self", "center", "important");
-  btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
+  btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 }
 

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -441,7 +441,6 @@ const FilterControl = L.Control.extend({
               tgt.dataset.clearing = "true";
               tgt.textContent = "Clearing\u2026";
               tgt.style.setProperty("background-color", "#545b62", "important");
-              tgt.style.setProperty("cursor", "not-allowed", "important");
               tgt.disabled = true;
               tgt.setAttribute("aria-disabled", "true");
               var url = new URL(window.location.href);
@@ -469,7 +468,6 @@ const FilterControl = L.Control.extend({
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
-          submitBtn.style.setProperty("cursor", "not-allowed", "important");
           submitBtn.disabled = true;
           submitBtn.setAttribute("aria-disabled", "true");
         }

--- a/smdb/smdb/static/js/map_expedition_filter.js
+++ b/smdb/smdb/static/js/map_expedition_filter.js
@@ -897,22 +897,32 @@ function _styleBtn(btn, borderColor) {
 }
 
 function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
+  var shadowColor = btn.classList.contains("btn-primary")
+    ? "rgba(0, 123, 255, 0.4)"
+    : "rgba(108, 117, 125, 0.4)";
+  var shadowColorActive = btn.classList.contains("btn-primary")
+    ? "rgba(0, 123, 255, 0.5)"
+    : "rgba(108, 117, 125, 0.5)";
   btn.addEventListener("mouseenter", function () {
     this.style.setProperty("background-color", hoverBg, "important");
     this.style.setProperty("border-color", hoverBorder, "important");
     this.style.setProperty("transform", "scale(1.05)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
   });
   btn.addEventListener("mouseleave", function () {
     this.style.removeProperty("background-color");
     this.style.removeProperty("border-color");
     this.style.setProperty("transform", "scale(1)", "important");
+    this.style.removeProperty("box-shadow");
   });
   btn.addEventListener("mousedown", function () {
     this.style.setProperty("background-color", activeBg, "important");
     this.style.setProperty("transform", "scale(0.97)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColorActive, "important");
   });
   btn.addEventListener("mouseup", function () {
     this.style.setProperty("background-color", hoverBg, "important");
     this.style.setProperty("transform", "scale(1.05)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
   });
 }

--- a/smdb/smdb/static/js/map_mission_filter.js
+++ b/smdb/smdb/static/js/map_mission_filter.js
@@ -519,7 +519,6 @@ const FilterControl = L.Control.extend({
             tgt.dataset.clearing = "true";
             tgt.textContent = "Clearing\u2026";
             tgt.style.setProperty("background-color", "#545b62", "important");
-            tgt.style.setProperty("cursor", "not-allowed", "important");
             tgt.disabled = true;
             tgt.setAttribute("aria-disabled", "true");
             var url = new URL(window.location.href);
@@ -552,7 +551,6 @@ const FilterControl = L.Control.extend({
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
-          submitBtn.style.setProperty("cursor", "not-allowed", "important");
           submitBtn.disabled = true;
           submitBtn.setAttribute("aria-disabled", "true");
         }

--- a/smdb/smdb/static/js/map_mission_filter.js
+++ b/smdb/smdb/static/js/map_mission_filter.js
@@ -1195,7 +1195,7 @@ function _styleBtn(btn, borderColor) {
   btn.style.setProperty("box-sizing", "border-box", "important");
   btn.style.setProperty("flex", "1 1 auto", "important");
   btn.style.setProperty("align-self", "center", "important");
-  btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
+  btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 }
 
 

--- a/smdb/smdb/static/js/map_mission_filter.js
+++ b/smdb/smdb/static/js/map_mission_filter.js
@@ -1193,40 +1193,9 @@ function _styleBtn(btn, borderColor) {
   btn.style.setProperty("box-sizing", "border-box", "important");
   btn.style.setProperty("flex", "1 1 auto", "important");
   btn.style.setProperty("align-self", "center", "important");
-  btn.style.setProperty("cursor", "pointer", "important");
   btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
 }
 
-function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
-  var shadowColor = btn.classList.contains("btn-primary")
-    ? "rgba(0, 123, 255, 0.4)"
-    : "rgba(108, 117, 125, 0.4)";
-  var shadowColorActive = btn.classList.contains("btn-primary")
-    ? "rgba(0, 123, 255, 0.5)"
-    : "rgba(108, 117, 125, 0.5)";
-  btn.addEventListener("mouseenter", function () {
-    this.style.setProperty("background-color", hoverBg, "important");
-    this.style.setProperty("border-color", hoverBorder, "important");
-    this.style.setProperty("transform", "scale(1.05)", "important");
-    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
-  });
-  btn.addEventListener("mouseleave", function () {
-    this.style.removeProperty("background-color");
-    this.style.removeProperty("border-color");
-    this.style.setProperty("transform", "scale(1)", "important");
-    this.style.removeProperty("box-shadow");
-  });
-  btn.addEventListener("mousedown", function () {
-    this.style.setProperty("background-color", activeBg, "important");
-    this.style.setProperty("transform", "scale(0.97)", "important");
-    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColorActive, "important");
-  });
-  btn.addEventListener("mouseup", function () {
-    this.style.setProperty("background-color", hoverBg, "important");
-    this.style.setProperty("transform", "scale(1.05)", "important");
-    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
-  });
-}
 
 // ---------------------------------------------------------------------------
 // initTableLayout — pins #mission-table-wrapper to the viewport as a fixed

--- a/smdb/smdb/static/js/map_mission_filter.js
+++ b/smdb/smdb/static/js/map_mission_filter.js
@@ -515,9 +515,13 @@ const FilterControl = L.Control.extend({
             e.preventDefault();
             e.stopPropagation();
             e.stopImmediatePropagation();
+            if (tgt.dataset.clearing === "true") { return false; }
+            tgt.dataset.clearing = "true";
             tgt.textContent = "Clearing\u2026";
             tgt.style.setProperty("background-color", "#545b62", "important");
             tgt.style.setProperty("cursor", "not-allowed", "important");
+            tgt.disabled = true;
+            tgt.setAttribute("aria-disabled", "true");
             var url = new URL(window.location.href);
             [
               "name", "region_name", "vehicle_name", "platformtype",
@@ -527,8 +531,8 @@ const FilterControl = L.Control.extend({
               "tmin", "tmax",
             ].forEach(function (k) { url.searchParams.delete(k); });
             var clearUrl = url.toString();
+            sessionStorage.setItem("sidebarOpen", "true");
             setTimeout(function () {
-              sessionStorage.setItem("sidebarOpen", "true");
               window.location.href = clearUrl;
             }, 80);
             return false;
@@ -541,12 +545,16 @@ const FilterControl = L.Control.extend({
       // Form submit: reload Missions page with filter params in URL.
       clonedForm.addEventListener("submit", function (e) {
         e.preventDefault();
+        if (clonedForm.dataset.submitting === "true") { return false; }
+        clonedForm.dataset.submitting = "true";
         var submitBtn = clonedForm.querySelector('[id$="FilterSubmit"]') ||
                         clonedForm.querySelector('[type="submit"]');
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
           submitBtn.style.setProperty("cursor", "not-allowed", "important");
+          submitBtn.disabled = true;
+          submitBtn.setAttribute("aria-disabled", "true");
         }
         var params = new URLSearchParams(new FormData(clonedForm));
         var url = new URL(window.location.href);

--- a/smdb/smdb/static/js/map_mission_filter.js
+++ b/smdb/smdb/static/js/map_mission_filter.js
@@ -1192,23 +1192,33 @@ function _styleBtn(btn, borderColor) {
 }
 
 function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
+  var shadowColor = btn.classList.contains("btn-primary")
+    ? "rgba(0, 123, 255, 0.4)"
+    : "rgba(108, 117, 125, 0.4)";
+  var shadowColorActive = btn.classList.contains("btn-primary")
+    ? "rgba(0, 123, 255, 0.5)"
+    : "rgba(108, 117, 125, 0.5)";
   btn.addEventListener("mouseenter", function () {
     this.style.setProperty("background-color", hoverBg, "important");
     this.style.setProperty("border-color", hoverBorder, "important");
     this.style.setProperty("transform", "scale(1.05)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
   });
   btn.addEventListener("mouseleave", function () {
     this.style.removeProperty("background-color");
     this.style.removeProperty("border-color");
     this.style.setProperty("transform", "scale(1)", "important");
+    this.style.removeProperty("box-shadow");
   });
   btn.addEventListener("mousedown", function () {
     this.style.setProperty("background-color", activeBg, "important");
     this.style.setProperty("transform", "scale(0.97)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColorActive, "important");
   });
   btn.addEventListener("mouseup", function () {
     this.style.setProperty("background-color", hoverBg, "important");
     this.style.setProperty("transform", "scale(1.05)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
   });
 }
 

--- a/smdb/smdb/static/js/map_mission_filter.js
+++ b/smdb/smdb/static/js/map_mission_filter.js
@@ -473,7 +473,7 @@ const FilterControl = L.Control.extend({
       filterBtn.className = "btn btn-primary";
       filterBtn.textContent = "Filter";
       _styleBtn(filterBtn, "#007bff");
-      _addBtnHoverFeedback(filterBtn, "#0069d9", "#0062cc", "#0062cc");
+      addBtnHoverFeedback(filterBtn, "#0069d9", "#0062cc", "#0062cc");
 
       const clearBtn = document.createElement("button");
       clearBtn.type = "reset";
@@ -481,7 +481,7 @@ const FilterControl = L.Control.extend({
       clearBtn.className = "btn btn-secondary";
       clearBtn.textContent = "Clear";
       _styleBtn(clearBtn, "#6c757d");
-      _addBtnHoverFeedback(clearBtn, "#5a6268", "#545b62", "#545b62");
+      addBtnHoverFeedback(clearBtn, "#5a6268", "#545b62", "#545b62");
 
       buttonRow.appendChild(filterBtn);
       buttonRow.appendChild(clearBtn);
@@ -519,6 +519,7 @@ const FilterControl = L.Control.extend({
             tgt.dataset.clearing = "true";
             tgt.textContent = "Clearing\u2026";
             tgt.style.setProperty("background-color", "#545b62", "important");
+            tgt.style.setProperty("border-color", "#545b62", "important");
             tgt.disabled = true;
             tgt.setAttribute("aria-disabled", "true");
             var url = new URL(window.location.href);
@@ -551,6 +552,7 @@ const FilterControl = L.Control.extend({
         if (submitBtn) {
           submitBtn.textContent = "Filtering\u2026";
           submitBtn.style.setProperty("background-color", "#0062cc", "important");
+          submitBtn.style.setProperty("border-color", "#0062cc", "important");
           submitBtn.disabled = true;
           submitBtn.setAttribute("aria-disabled", "true");
         }

--- a/smdb/smdb/static/js/map_mission_filter.js
+++ b/smdb/smdb/static/js/map_mission_filter.js
@@ -473,6 +473,7 @@ const FilterControl = L.Control.extend({
       filterBtn.className = "btn btn-primary";
       filterBtn.textContent = "Filter";
       _styleBtn(filterBtn, "#007bff");
+      _addBtnHoverFeedback(filterBtn, "#0069d9", "#0062cc", "#0062cc");
 
       const clearBtn = document.createElement("button");
       clearBtn.type = "reset";
@@ -480,6 +481,7 @@ const FilterControl = L.Control.extend({
       clearBtn.className = "btn btn-secondary";
       clearBtn.textContent = "Clear";
       _styleBtn(clearBtn, "#6c757d");
+      _addBtnHoverFeedback(clearBtn, "#5a6268", "#545b62", "#545b62");
 
       buttonRow.appendChild(filterBtn);
       buttonRow.appendChild(clearBtn);
@@ -513,7 +515,9 @@ const FilterControl = L.Control.extend({
             e.preventDefault();
             e.stopPropagation();
             e.stopImmediatePropagation();
-            sessionStorage.setItem("sidebarOpen", "true");
+            tgt.textContent = "Clearing\u2026";
+            tgt.style.setProperty("background-color", "#545b62", "important");
+            tgt.style.setProperty("cursor", "not-allowed", "important");
             var url = new URL(window.location.href);
             [
               "name", "region_name", "vehicle_name", "platformtype",
@@ -522,7 +526,11 @@ const FilterControl = L.Control.extend({
               "filter_type", "q", "xmin", "xmax", "ymin", "ymax",
               "tmin", "tmax",
             ].forEach(function (k) { url.searchParams.delete(k); });
-            window.location.href = url.toString();
+            var clearUrl = url.toString();
+            setTimeout(function () {
+              sessionStorage.setItem("sidebarOpen", "true");
+              window.location.href = clearUrl;
+            }, 80);
             return false;
           }
         },
@@ -533,6 +541,13 @@ const FilterControl = L.Control.extend({
       // Form submit: reload Missions page with filter params in URL.
       clonedForm.addEventListener("submit", function (e) {
         e.preventDefault();
+        var submitBtn = clonedForm.querySelector('[id$="FilterSubmit"]') ||
+                        clonedForm.querySelector('[type="submit"]');
+        if (submitBtn) {
+          submitBtn.textContent = "Filtering\u2026";
+          submitBtn.style.setProperty("background-color", "#0062cc", "important");
+          submitBtn.style.setProperty("cursor", "not-allowed", "important");
+        }
         var params = new URLSearchParams(new FormData(clonedForm));
         var url = new URL(window.location.href);
         [
@@ -545,7 +560,10 @@ const FilterControl = L.Control.extend({
         params.forEach(function (val, key) {
           if (val) url.searchParams.append(key, val);
         });
-        window.location.href = url.toString();
+        var filterUrl = url.toString();
+        setTimeout(function () {
+          window.location.href = filterUrl;
+        }, 80);
       });
 
       // Style form inputs for the dark sidebar theme.
@@ -1169,6 +1187,29 @@ function _styleBtn(btn, borderColor) {
   btn.style.setProperty("box-sizing", "border-box", "important");
   btn.style.setProperty("flex", "1 1 auto", "important");
   btn.style.setProperty("align-self", "center", "important");
+  btn.style.setProperty("cursor", "pointer", "important");
+  btn.style.setProperty("transition", "background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, transform 0.12s ease-in-out", "important");
+}
+
+function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
+  btn.addEventListener("mouseenter", function () {
+    this.style.setProperty("background-color", hoverBg, "important");
+    this.style.setProperty("border-color", hoverBorder, "important");
+    this.style.setProperty("transform", "scale(1.05)", "important");
+  });
+  btn.addEventListener("mouseleave", function () {
+    this.style.removeProperty("background-color");
+    this.style.removeProperty("border-color");
+    this.style.setProperty("transform", "scale(1)", "important");
+  });
+  btn.addEventListener("mousedown", function () {
+    this.style.setProperty("background-color", activeBg, "important");
+    this.style.setProperty("transform", "scale(0.97)", "important");
+  });
+  btn.addEventListener("mouseup", function () {
+    this.style.setProperty("background-color", hoverBg, "important");
+    this.style.setProperty("transform", "scale(1.05)", "important");
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/smdb/smdb/static/js/project.js
+++ b/smdb/smdb/static/js/project.js
@@ -130,3 +130,46 @@ function setupCheckboxDropdowns(formEl, recalcCallback) {
     });
   });
 }
+
+/**
+ * Shared hover/active feedback for sidebar Filter and Clear buttons.
+ * Adds mouseenter/leave/down/up listeners that darken the background,
+ * scale the button, and show a matching box-shadow glow on hover.
+ * Used by map_mission_filter.js, map_expedition_filter.js, and
+ * map_compilation_filter.js.
+ *
+ * @param {HTMLElement} btn        - The button element to enhance.
+ * @param {string}      hoverBg    - Background colour on hover.
+ * @param {string}      hoverBorder - Border colour on hover.
+ * @param {string}      activeBg   - Background colour on mousedown.
+ */
+function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
+  var shadowColor = btn.classList.contains("btn-primary")
+    ? "rgba(0, 123, 255, 0.4)"
+    : "rgba(108, 117, 125, 0.4)";
+  var shadowColorActive = btn.classList.contains("btn-primary")
+    ? "rgba(0, 123, 255, 0.5)"
+    : "rgba(108, 117, 125, 0.5)";
+  btn.addEventListener("mouseenter", function () {
+    this.style.setProperty("background-color", hoverBg, "important");
+    this.style.setProperty("border-color", hoverBorder, "important");
+    this.style.setProperty("transform", "scale(1.05)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
+  });
+  btn.addEventListener("mouseleave", function () {
+    this.style.removeProperty("background-color");
+    this.style.removeProperty("border-color");
+    this.style.setProperty("transform", "scale(1)", "important");
+    this.style.removeProperty("box-shadow");
+  });
+  btn.addEventListener("mousedown", function () {
+    this.style.setProperty("background-color", activeBg, "important");
+    this.style.setProperty("transform", "scale(0.97)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColorActive, "important");
+  });
+  btn.addEventListener("mouseup", function () {
+    this.style.setProperty("background-color", hoverBg, "important");
+    this.style.setProperty("transform", "scale(1.05)", "important");
+    this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
+  });
+}

--- a/smdb/smdb/static/js/project.js
+++ b/smdb/smdb/static/js/project.js
@@ -138,12 +138,12 @@ function setupCheckboxDropdowns(formEl, recalcCallback) {
  * Used by map_mission_filter.js, map_expedition_filter.js, and
  * map_compilation_filter.js.
  *
- * @param {HTMLElement} btn        - The button element to enhance.
- * @param {string}      hoverBg    - Background colour on hover.
- * @param {string}      hoverBorder - Border colour on hover.
- * @param {string}      activeBg   - Background colour on mousedown.
+ * @param {HTMLElement} btn         - The button element to enhance.
+ * @param {string}      hoverBg     - Background color on hover.
+ * @param {string}      hoverBorder - Border color on hover.
+ * @param {string}      activeBg    - Background color on mousedown.
  */
-function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
+function addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
   var shadowColor = btn.classList.contains("btn-primary")
     ? "rgba(0, 123, 255, 0.4)"
     : "rgba(108, 117, 125, 0.4)";
@@ -164,11 +164,13 @@ function _addBtnHoverFeedback(btn, hoverBg, hoverBorder, activeBg) {
   });
   btn.addEventListener("mousedown", function () {
     this.style.setProperty("background-color", activeBg, "important");
+    this.style.setProperty("border-color", hoverBorder, "important");
     this.style.setProperty("transform", "scale(0.97)", "important");
     this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColorActive, "important");
   });
   btn.addEventListener("mouseup", function () {
     this.style.setProperty("background-color", hoverBg, "important");
+    this.style.setProperty("border-color", hoverBorder, "important");
     this.style.setProperty("transform", "scale(1.05)", "important");
     this.style.setProperty("box-shadow", "0 0 0 0.2rem " + shadowColor, "important");
   });

--- a/smdb/smdb/templates/smdb/compilation_filter.html
+++ b/smdb/smdb/templates/smdb/compilation_filter.html
@@ -75,7 +75,7 @@
 
     {{ missions|json_script:"missions-data" }}
     <div id="map_compilation_filter" style="height: 50vh; min-height: 300px;"></div>
-    <script src="{% static 'js/map_compilation_filter.js' %}"></script>
+    <script defer src="{% static 'js/map_compilation_filter.js' %}"></script>
 
     <div id="compilation-table-wrapper">
       {% if table %}

--- a/smdb/smdb/templates/smdb/expedition_filter.html
+++ b/smdb/smdb/templates/smdb/expedition_filter.html
@@ -75,7 +75,7 @@
 
     {{ missions|json_script:"missions-data" }}
     <div id="map_expedition_filter" style="height: 50vh; min-height: 300px;"></div>
-    <script src="{% static 'js/map_expedition_filter.js' %}"></script>
+    <script defer src="{% static 'js/map_expedition_filter.js' %}"></script>
 
     <div id="expedition-table-wrapper">
       {% if table %}

--- a/smdb/smdb/templates/smdb/mission_filter.html
+++ b/smdb/smdb/templates/smdb/mission_filter.html
@@ -75,7 +75,7 @@
 
     {{ missions|json_script:"missions-data" }}
     <div id="map_mission_filter" style="height: 50vh; min-height: 300px;"></div>
-    <script src="{% static 'js/map_mission_filter.js' %}"></script>
+    <script defer src="{% static 'js/map_mission_filter.js' %}"></script>
 
     <div id="mission-table-wrapper">
       {% if table %}


### PR DESCRIPTION
## Summary

Implements **issue #297**: reactive hover and click feedback on the Missions (and shared) sidebar **Filter** and **Clear** buttons — CSS-injected transitions, box-shadow, and cursor behavior in `map.js` / `project.js` (see granular commits on this branch).

**Upstream:** This work was merged to `mbari-org/SeafloorMappingDB` as [**PR #299**](https://github.com/mbari-org/SeafloorMappingDB/pull/299) (merged 2026-04-13). Your fork's `develop` contains the same end state as a squash-style merge (`d3a85e4`).

## Why this PR exists

- **Git tree** of `feature/issue-297-filter-btn-hover-feedback-v2` matches `develop` (identical content).
- **Git history** differs (incremental Copilot rounds on this branch vs single merge commit on `develop`).
- Use this PR for **GitHub Copilot** / reviewer diffs on the **branch history** if helpful; merging may produce an **empty merge** or align histories—optional.

Does **not** supersede or reopen mbari-org#299.

## Related

- Related: [mbari-org#297](https://github.com/mbari-org/SeafloorMappingDB/issues/297), [mbari-org#299](https://github.com/mbari-org/SeafloorMappingDB/pull/299)

## Copilot

Please run **Copilot code review** on the Files changed tab (`map.js`, `project.js`, etc.).

## Testing

Missions / Expeditions / Compilations filter sidebars: hover Filter and Clear; confirm visual feedback and no stuck `not-allowed` cursor after click.